### PR TITLE
feat(dictation): add de commands, fr commands, and replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ the SDK and as a validation tool when upgrading to a new SDK version.
 |--------------------------------------------------------------------------------------|---------------------|----------------------------------------------------------------------------------------------|
 | [dictation/typescript/basic-example/](dictation/typescript/basic-example/)           | TypeScript, Express | Microphone streaming via the Corti SDK; interim + final transcripts; voice commands          |
 | [dictation/typescript/web-component/](dictation/typescript/web-component/)           | TypeScript, Express | Four demos of `@corti/dictation-web`: basic, custom UI, styling, and token refresh           |
-| [dictation/commands/](dictation/commands/)                                           | Json                | English voice-command phrase JSON (templates, dictation box, editing, lists, navigation, selection) |
+| [dictation/commands/](dictation/commands/)                                           | Json                | Command configuration JSON (templates, dictation box, editing, lists, navigation, selection) |
+| [dictation/replacements/](dictation/replacements/)                                   | Json                | Replacements configuration JSON (numbered list items, Roman numerals) |
 
 ---
 

--- a/dictation/commands/de/auto-text.json
+++ b/dictation/commands/de/auto-text.json
@@ -1,38 +1,68 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "insert_template",
         "_comment": "Use to insert a pre-defined template. Example: 'insert soap template' (Vordefinierte Vorlage einfügen. Beispiel: 'soap-Vorlage einfügen')",
-        "phrases": ["meine {template_name}-Vorlage einfügen", "{template_name}-Vorlage einfügen"],
+        "phrases": [
+          "meine {template_name}-Vorlage einfügen",
+          "{template_name}-Vorlage einfügen"
+        ],
         "variables": [
           {
             "key": "template_name",
             "type": "enum",
-            "enum": ["soap", "radiologie", "überweisung", "brief", "patientenzusammenfassung", "h und p", "ambulanznotiz", "verlaufsnotiz", "pflege"]
+            "enum": [
+              "soap",
+              "radiologie",
+              "überweisung",
+              "brief",
+              "patientenzusammenfassung",
+              "h und p",
+              "ambulanznotiz",
+              "verlaufsnotiz",
+              "pflege"
+            ]
           }
         ]
       },
       {
         "id": "insert_exam",
         "_comment": "Use to insert a pre-defined exam template. Example: 'insert normal exam' (Vordefinierte Untersuchungsvorlage einfügen. Beispiel: 'normale Untersuchung einfügen')",
-        "phrases": ["{type} Untersuchung einfügen"],
+        "phrases": [
+          "{type} Untersuchung einfügen"
+        ],
         "variables": [
           {
             "key": "type",
             "type": "enum",
-            "enum": ["normale", "männliche", "weibliche", "kurze", "umfassende"]
+            "enum": [
+              "normale",
+              "männliche",
+              "weibliche",
+              "kurze",
+              "umfassende"
+            ]
           }
         ]
       },
       {
         "id": "insert_attestation",
         "_comment": "Use to insert a pre-defined attestation macro. Example: 'insert attestation' (Vordefiniertes Attest einfügen. Beispiel: 'Attest einfügen')",
-        "phrases": ["Attest einfügen"]
+        "phrases": [
+          "Attest einfügen"
+        ]
       },
       {
         "id": "insert_signature",
         "_comment": "Use to insert a pre-defined signature macro. Example: 'insert signature' or 'sign the note' (Vordefinierte Unterschrift einfügen. Beispiel: 'Unterschrift einfügen' oder 'Notiz unterschreiben')",
-        "phrases": ["Unterschrift einfügen", "Notiz unterschreiben"]
+        "phrases": [
+          "Unterschrift einfügen",
+          "Notiz unterschreiben"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/de/auto-text.json
+++ b/dictation/commands/de/auto-text.json
@@ -1,0 +1,38 @@
+{
+    "commands": [
+      {
+        "id": "insert_template",
+        "_comment": "Use to insert a pre-defined template. Example: 'insert soap template' (Vordefinierte Vorlage einfügen. Beispiel: 'soap-Vorlage einfügen')",
+        "phrases": ["meine {template_name}-Vorlage einfügen", "{template_name}-Vorlage einfügen"],
+        "variables": [
+          {
+            "key": "template_name",
+            "type": "enum",
+            "enum": ["soap", "radiologie", "überweisung", "brief", "patientenzusammenfassung", "h und p", "ambulanznotiz", "verlaufsnotiz", "pflege"]
+          }
+        ]
+      },
+      {
+        "id": "insert_exam",
+        "_comment": "Use to insert a pre-defined exam template. Example: 'insert normal exam' (Vordefinierte Untersuchungsvorlage einfügen. Beispiel: 'normale Untersuchung einfügen')",
+        "phrases": ["{type} Untersuchung einfügen"],
+        "variables": [
+          {
+            "key": "type",
+            "type": "enum",
+            "enum": ["normale", "männliche", "weibliche", "kurze", "umfassende"]
+          }
+        ]
+      },
+      {
+        "id": "insert_attestation",
+        "_comment": "Use to insert a pre-defined attestation macro. Example: 'insert attestation' (Vordefiniertes Attest einfügen. Beispiel: 'Attest einfügen')",
+        "phrases": ["Attest einfügen"]
+      },
+      {
+        "id": "insert_signature",
+        "_comment": "Use to insert a pre-defined signature macro. Example: 'insert signature' or 'sign the note' (Vordefinierte Unterschrift einfügen. Beispiel: 'Unterschrift einfügen' oder 'Notiz unterschreiben')",
+        "phrases": ["Unterschrift einfügen", "Notiz unterschreiben"]
+      }
+    ]
+}

--- a/dictation/commands/de/dictation-box.json
+++ b/dictation/commands/de/dictation-box.json
@@ -1,21 +1,36 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "dictation_window",
         "_comment": "Use to control the dictation window if one is available in the application. Example: 'open dictation window' (Diktierfenster steuern, wenn in der Anwendung verfügbar. Beispiel: 'Diktierfenster öffnen')",
-        "phrases": ["Diktierfenster {action}"],
+        "phrases": [
+          "Diktierfenster {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["öffnen", "schließen", "anzeigen", "ausblenden", "verankern", "lösen"]
+            "enum": [
+              "öffnen",
+              "schließen",
+              "anzeigen",
+              "ausblenden",
+              "verankern",
+              "lösen"
+            ]
           }
         ]
       },
       {
         "id": "transfer_text",
         "_comment": "Use to transfer text from the dictation window to the cursor location. Example: 'transfer text' (Text aus dem Diktierfenster an die Cursorposition übertragen. Beispiel: 'Text übertragen')",
-        "phrases": ["Text übertragen"]
+        "phrases": [
+          "Text übertragen"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/de/dictation-box.json
+++ b/dictation/commands/de/dictation-box.json
@@ -1,0 +1,21 @@
+{
+    "commands": [
+      {
+        "id": "dictation_window",
+        "_comment": "Use to control the dictation window if one is available in the application. Example: 'open dictation window' (Diktierfenster steuern, wenn in der Anwendung verfügbar. Beispiel: 'Diktierfenster öffnen')",
+        "phrases": ["Diktierfenster {action}"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["öffnen", "schließen", "anzeigen", "ausblenden", "verankern", "lösen"]
+          }
+        ]
+      },
+      {
+        "id": "transfer_text",
+        "_comment": "Use to transfer text from the dictation window to the cursor location. Example: 'transfer text' (Text aus dem Diktierfenster an die Cursorposition übertragen. Beispiel: 'Text übertragen')",
+        "phrases": ["Text übertragen"]
+      }
+    ]
+}

--- a/dictation/commands/de/editing.json
+++ b/dictation/commands/de/editing.json
@@ -1,91 +1,171 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "edit_that",
         "_comment": "Use to edit the selected text. Example: 'delete that' or 'undo that' (Ausgewählten Text bearbeiten. Beispiel: 'das löschen' oder 'das rückgängig')",
-        "phrases": ["das {action}"],
+        "phrases": [
+          "das {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["löschen", "verwerfen", "rückgängig", "wiederholen", "ausschneiden", "kopieren", "einfügen", "korrigieren"]
+            "enum": [
+              "löschen",
+              "verwerfen",
+              "rückgängig",
+              "wiederholen",
+              "ausschneiden",
+              "kopieren",
+              "einfügen",
+              "korrigieren"
+            ]
           }
         ]
       },
       {
         "id": "delete_selection",
         "_comment": "Use to delete the text relative to cursor position. Example: 'delete last sentence' (Text relativ zur Cursorposition löschen. Beispiel: 'letzten Satz löschen')",
-        "phrases": ["{choice} {location} löschen"],
+        "phrases": [
+          "{choice} {location} löschen"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+            "enum": [
+              "aktuellen",
+              "aktuelles",
+              "diesen",
+              "dieses",
+              "letzten",
+              "letztes",
+              "vorherigen",
+              "vorheriges",
+              "nächsten",
+              "nächstes"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Wort", "Satz", "Absatz"]
+            "enum": [
+              "Wort",
+              "Satz",
+              "Absatz"
+            ]
           }
         ]
       },
       {
         "id": "copy_selection",
         "_comment": "Use to copy the text relative to cursor position. Example: 'copy current sentence' (Text relativ zur Cursorposition kopieren. Beispiel: 'aktuellen Satz kopieren')",
-        "phrases": ["{choice} {location} kopieren"],
+        "phrases": [
+          "{choice} {location} kopieren"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+            "enum": [
+              "aktuellen",
+              "aktuelles",
+              "diesen",
+              "dieses",
+              "letzten",
+              "letztes",
+              "vorherigen",
+              "vorheriges",
+              "nächsten",
+              "nächstes"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Wort", "Satz", "Absatz"]
+            "enum": [
+              "Wort",
+              "Satz",
+              "Absatz"
+            ]
           }
         ]
       },
       {
         "id": "cut_selection",
         "_comment": "Use to cut the text relative to cursor position. Example: 'cut current sentence' (Text relativ zur Cursorposition ausschneiden. Beispiel: 'aktuellen Satz ausschneiden')",
-        "phrases": ["{choice} {location} ausschneiden"],
+        "phrases": [
+          "{choice} {location} ausschneiden"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+            "enum": [
+              "aktuellen",
+              "aktuelles",
+              "diesen",
+              "dieses",
+              "letzten",
+              "letztes",
+              "vorherigen",
+              "vorheriges",
+              "nächsten",
+              "nächstes"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Wort", "Satz", "Absatz"]
+            "enum": [
+              "Wort",
+              "Satz",
+              "Absatz"
+            ]
           }
         ]
       },
       {
         "id": "format_selection",
         "_comment": "Use to format the selected text. Example: 'format that bold' (Ausgewählten Text formatieren. Beispiel: 'das fett formatieren')",
-        "phrases": ["das {style} formatieren", "{style} formatieren"],
+        "phrases": [
+          "das {style} formatieren",
+          "{style} formatieren"
+        ],
         "variables": [
           {
             "key": "style",
             "type": "enum",
-            "enum": ["fett", "kursiv", "unterstrichen", "normal"]
+            "enum": [
+              "fett",
+              "kursiv",
+              "unterstrichen",
+              "normal"
+            ]
           }
         ]
       },
       {
         "id": "cap_that",
         "_comment": "Use to capitalize the selected text. Example: 'cap that' or 'all caps on' (Ausgewählten Text in Großbuchstaben umwandeln. Beispiel: 'Großbuchstaben ein' oder 'Großbuchstaben aus')",
-        "phrases": ["Großbuchstaben {action}"],
+        "phrases": [
+          "Großbuchstaben {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["ein", "aus", "das"]
+            "enum": [
+              "ein",
+              "aus",
+              "das"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/de/editing.json
+++ b/dictation/commands/de/editing.json
@@ -1,0 +1,91 @@
+{
+    "commands": [
+      {
+        "id": "edit_that",
+        "_comment": "Use to edit the selected text. Example: 'delete that' or 'undo that' (Ausgewählten Text bearbeiten. Beispiel: 'das löschen' oder 'das rückgängig')",
+        "phrases": ["das {action}"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["löschen", "verwerfen", "rückgängig", "wiederholen", "ausschneiden", "kopieren", "einfügen", "korrigieren"]
+          }
+        ]
+      },
+      {
+        "id": "delete_selection",
+        "_comment": "Use to delete the text relative to cursor position. Example: 'delete last sentence' (Text relativ zur Cursorposition löschen. Beispiel: 'letzten Satz löschen')",
+        "phrases": ["{choice} {location} löschen"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Wort", "Satz", "Absatz"]
+          }
+        ]
+      },
+      {
+        "id": "copy_selection",
+        "_comment": "Use to copy the text relative to cursor position. Example: 'copy current sentence' (Text relativ zur Cursorposition kopieren. Beispiel: 'aktuellen Satz kopieren')",
+        "phrases": ["{choice} {location} kopieren"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Wort", "Satz", "Absatz"]
+          }
+        ]
+      },
+      {
+        "id": "cut_selection",
+        "_comment": "Use to cut the text relative to cursor position. Example: 'cut current sentence' (Text relativ zur Cursorposition ausschneiden. Beispiel: 'aktuellen Satz ausschneiden')",
+        "phrases": ["{choice} {location} ausschneiden"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuellen", "aktuelles", "diesen", "dieses", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Wort", "Satz", "Absatz"]
+          }
+        ]
+      },
+      {
+        "id": "format_selection",
+        "_comment": "Use to format the selected text. Example: 'format that bold' (Ausgewählten Text formatieren. Beispiel: 'das fett formatieren')",
+        "phrases": ["das {style} formatieren", "{style} formatieren"],
+        "variables": [
+          {
+            "key": "style",
+            "type": "enum",
+            "enum": ["fett", "kursiv", "unterstrichen", "normal"]
+          }
+        ]
+      },
+      {
+        "id": "cap_that",
+        "_comment": "Use to capitalize the selected text. Example: 'cap that' or 'all caps on' (Ausgewählten Text in Großbuchstaben umwandeln. Beispiel: 'Großbuchstaben ein' oder 'Großbuchstaben aus')",
+        "phrases": ["Großbuchstaben {action}"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["ein", "aus", "das"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/de/lists.json
+++ b/dictation/commands/de/lists.json
@@ -1,0 +1,40 @@
+{
+    "commands": [
+      {
+        "id": "new_list",
+        "_comment": "Use to create a new list. Example: 'new list' or 'bullet list' (Neue Liste erstellen. Beispiel: 'neue Liste' oder 'Aufzählungsliste')",
+        "phrases": ["{action} Liste"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["neue", "einfügen", "starten", "beenden", "Aufzählungs", "Aufzählung", "nummerierte", "nummerierten", "ungeordnete", "geordnete"]
+          }
+        ]
+      },
+      {
+        "id": "next_item",
+        "_comment": "Use to navigate to the next item in the current list. Example: 'next item' (Zum nächsten Element in der aktuellen Liste navigieren. Beispiel: 'nächstes Element')",
+        "phrases": ["nächstes {item}", "{item} weiter"],
+        "variables": [
+          {
+            "key": "item",
+            "type": "enum",
+            "enum": ["Element", "Aufzählungspunkt", "Nummer"]
+          }
+        ]
+      },
+      {
+        "id": "list_number",
+        "_comment": "Use to navigate or insert a specific item in a list. Example: 'list item three' (Zu einem bestimmten Listenelement navigieren oder es einfügen. Beispiel: 'Listenelement drei')",
+        "phrases": ["Element {number}", "Listenelement {number}", "Listennummer {number}"],
+        "variables": [
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/de/lists.json
+++ b/dictation/commands/de/lists.json
@@ -1,40 +1,79 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "new_list",
         "_comment": "Use to create a new list. Example: 'new list' or 'bullet list' (Neue Liste erstellen. Beispiel: 'neue Liste' oder 'Aufzählungsliste')",
-        "phrases": ["{action} Liste"],
+        "phrases": [
+          "{action} Liste"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["neue", "einfügen", "starten", "beenden", "Aufzählungs", "Aufzählung", "nummerierte", "nummerierten", "ungeordnete", "geordnete"]
+            "enum": [
+              "neue",
+              "einfügen",
+              "starten",
+              "beenden",
+              "Aufzählungs",
+              "Aufzählung",
+              "nummerierte",
+              "nummerierten",
+              "ungeordnete",
+              "geordnete"
+            ]
           }
         ]
       },
       {
         "id": "next_item",
         "_comment": "Use to navigate to the next item in the current list. Example: 'next item' (Zum nächsten Element in der aktuellen Liste navigieren. Beispiel: 'nächstes Element')",
-        "phrases": ["nächstes {item}", "{item} weiter"],
+        "phrases": [
+          "nächstes {item}",
+          "{item} weiter"
+        ],
         "variables": [
           {
             "key": "item",
             "type": "enum",
-            "enum": ["Element", "Aufzählungspunkt", "Nummer"]
+            "enum": [
+              "Element",
+              "Aufzählungspunkt",
+              "Nummer"
+            ]
           }
         ]
       },
       {
         "id": "list_number",
         "_comment": "Use to navigate or insert a specific item in a list. Example: 'list item three' (Zu einem bestimmten Listenelement navigieren oder es einfügen. Beispiel: 'Listenelement drei')",
-        "phrases": ["Element {number}", "Listenelement {number}", "Listennummer {number}"],
+        "phrases": [
+          "Element {number}",
+          "Listenelement {number}",
+          "Listennummer {number}"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn"]
+            "enum": [
+              "eins",
+              "zwei",
+              "drei",
+              "vier",
+              "fünf",
+              "sechs",
+              "sieben",
+              "acht",
+              "neun",
+              "zehn"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/de/navigation.json
+++ b/dictation/commands/de/navigation.json
@@ -1,60 +1,111 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "navigate_fields",
         "_comment": "Use to navigate between fields in the current text area. Example: 'next field' (Zwischen Feldern im aktuellen Textbereich navigieren. Beispiel: 'nächstes Feld')",
-        "phrases": ["{choice} {location}"],
+        "phrases": [
+          "{choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["nächstes", "nächster", "vorheriges", "vorheriger", "erstes", "erster", "letztes", "letzter"]
+            "enum": [
+              "nächstes",
+              "nächster",
+              "vorheriges",
+              "vorheriger",
+              "erstes",
+              "erster",
+              "letztes",
+              "letzter"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Feld", "Abschnitt", "Steuerelement"]
+            "enum": [
+              "Feld",
+              "Abschnitt",
+              "Steuerelement"
+            ]
           }
         ]
       },
       {
         "id": "go_to",
         "_comment": "Use to go to a specific location in the current text area. Example: 'go to end of document' (An eine bestimmte Stelle im aktuellen Textbereich springen. Beispiel: 'zum Ende des Dokuments')",
-        "phrases": ["zum {choice} des {location} gehen", "zum {choice} des {location}"],
+        "phrases": [
+          "zum {choice} des {location} gehen",
+          "zum {choice} des {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["Anfang", "Beginn", "Ende"]
+            "enum": [
+              "Anfang",
+              "Beginn",
+              "Ende"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Zeile", "Absatzes", "Dokuments"]
+            "enum": [
+              "Zeile",
+              "Absatzes",
+              "Dokuments"
+            ]
           }
         ]
       },
       {
         "id": "insert_cursor",
         "_comment": "Use to insert a cursor at a specific location in the current text area. Example: 'insert before current paragraph' (Cursor an einer bestimmten Stelle einfügen. Beispiel: 'vor aktuellem Absatz einfügen')",
-        "phrases": ["Cursor {direction} {choice} {location} einfügen"],
+        "phrases": [
+          "Cursor {direction} {choice} {location} einfügen"
+        ],
         "variables": [
           {
             "key": "direction",
             "type": "enum",
-            "enum": ["vor", "nach"]
+            "enum": [
+              "vor",
+              "nach"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuellem", "aktueller", "erstem", "erster", "letztem", "letzter", "vorherigem", "vorheriger", "nächstem", "nächster"]
+            "enum": [
+              "aktuellem",
+              "aktueller",
+              "erstem",
+              "erster",
+              "letztem",
+              "letzter",
+              "vorherigem",
+              "vorheriger",
+              "nächstem",
+              "nächster"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["Zeile", "Wort", "Absatz", "Dokument"]
+            "enum": [
+              "Zeile",
+              "Wort",
+              "Absatz",
+              "Dokument"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/de/navigation.json
+++ b/dictation/commands/de/navigation.json
@@ -1,0 +1,60 @@
+{
+    "commands": [
+      {
+        "id": "navigate_fields",
+        "_comment": "Use to navigate between fields in the current text area. Example: 'next field' (Zwischen Feldern im aktuellen Textbereich navigieren. Beispiel: 'nächstes Feld')",
+        "phrases": ["{choice} {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["nächstes", "nächster", "vorheriges", "vorheriger", "erstes", "erster", "letztes", "letzter"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Feld", "Abschnitt", "Steuerelement"]
+          }
+        ]
+      },
+      {
+        "id": "go_to",
+        "_comment": "Use to go to a specific location in the current text area. Example: 'go to end of document' (An eine bestimmte Stelle im aktuellen Textbereich springen. Beispiel: 'zum Ende des Dokuments')",
+        "phrases": ["zum {choice} des {location} gehen", "zum {choice} des {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["Anfang", "Beginn", "Ende"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Zeile", "Absatzes", "Dokuments"]
+          }
+        ]
+      },
+      {
+        "id": "insert_cursor",
+        "_comment": "Use to insert a cursor at a specific location in the current text area. Example: 'insert before current paragraph' (Cursor an einer bestimmten Stelle einfügen. Beispiel: 'vor aktuellem Absatz einfügen')",
+        "phrases": ["Cursor {direction} {choice} {location} einfügen"],
+        "variables": [
+          {
+            "key": "direction",
+            "type": "enum",
+            "enum": ["vor", "nach"]
+          },
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuellem", "aktueller", "erstem", "erster", "letztem", "letzter", "vorherigem", "vorheriger", "nächstem", "nächster"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["Zeile", "Wort", "Absatz", "Dokument"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/de/select.json
+++ b/dictation/commands/de/select.json
@@ -61,7 +61,19 @@
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Eine Option oder Auswahl aus einer Liste auswählen. Beispiel: 'Option drei auswählen')",
-        "phrases": ["{choice} {number} auswählen", "{number} {choice} auswählen", "{number} auswählen", "{number} {choice} wählen", "{number} wählen"],
+        "phrases": ["{number} auswählen, {number} wählen"],
+        "variables": [
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["eins", "zwei", "drei", "vier", "fünf", "erste", "zweite", "dritte", "vierte", "fünfte"]
+          }
+        ]
+      },
+      {
+        "id": "select_choice_number",
+        "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Eine Option oder Auswahl aus einer Liste auswählen. Beispiel: 'Option drei auswählen')",
+        "phrases": ["{choice} {number} auswählen", "{number} {choice} auswählen, {number} {choice} wählen"],
         "variables": [
           {
             "key": "choice",

--- a/dictation/commands/de/select.json
+++ b/dictation/commands/de/select.json
@@ -1,0 +1,79 @@
+{
+    "commands": [
+      {
+        "id": "select",
+        "_comment": "Use to select all text in current text area. Example: 'select all' (Gesamten Text im aktuellen Textbereich auswählen. Beispiel: 'alles auswählen')",
+        "phrases": ["{selection} auswählen"],
+        "variables": [
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["alles", "das"]
+          }
+        ]
+      },
+      {
+        "id": "unselect",
+        "_comment": "Use to unselect text selection. Example: 'unselect text' (Textauswahl aufheben. Beispiel: 'Text abwählen')",
+        "phrases": ["{selection} abwählen", "{selection} deselektieren", "{selection} löschen"],
+        "variables": [
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["alles", "das", "Text", "Auswahl"]
+          }
+        ]
+      },
+      {
+        "id": "select_that",
+        "_comment": "Use to select a sentence in the current text area. Example: 'select current sentence' (Einen Satz im aktuellen Textbereich auswählen. Beispiel: 'aktuellen Satz auswählen')",
+        "phrases": ["{choice} {selection} auswählen"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuellen", "aktuelles", "ersten", "erstes", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+          },
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["Wort", "Satz", "Absatz"]
+          }
+        ]
+      },
+      {
+        "id": "select_number_of_words",
+        "_comment": "Use to select a number of words relative to cursor position within the current text area. Example: 'select next three words' (Eine bestimmte Anzahl Wörter relativ zur Cursorposition auswählen. Beispiel: 'nächste drei Wörter auswählen')",
+        "phrases": ["{choice} {number} Wörter auswählen", "{choice} {number} Wort auswählen"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["aktuelle", "erste", "letzte", "vorherige", "nächste"]
+          },
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn"]
+          }
+        ]
+      },
+      {
+        "id": "select_number",
+        "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Eine Option oder Auswahl aus einer Liste auswählen. Beispiel: 'Option drei auswählen')",
+        "phrases": ["{choice} {number} auswählen", "{number} {choice} auswählen", "{number} auswählen", "{number} {choice} wählen", "{number} wählen"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["Auswahl", "Option", "Nummer", "Element"]
+          },
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["eins", "zwei", "drei", "vier", "fünf", "erste", "zweite", "dritte", "vierte", "fünfte"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/de/select.json
+++ b/dictation/commands/de/select.json
@@ -1,91 +1,178 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
     "commands": [
       {
         "id": "select",
         "_comment": "Use to select all text in current text area. Example: 'select all' (Gesamten Text im aktuellen Textbereich auswählen. Beispiel: 'alles auswählen')",
-        "phrases": ["{selection} auswählen"],
+        "phrases": [
+          "{selection} auswählen"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["alles", "das"]
+            "enum": [
+              "alles",
+              "das"
+            ]
           }
         ]
       },
       {
         "id": "unselect",
         "_comment": "Use to unselect text selection. Example: 'unselect text' (Textauswahl aufheben. Beispiel: 'Text abwählen')",
-        "phrases": ["{selection} abwählen", "{selection} deselektieren", "{selection} löschen"],
+        "phrases": [
+          "{selection} abwählen",
+          "{selection} deselektieren",
+          "{selection} löschen"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["alles", "das", "Text", "Auswahl"]
+            "enum": [
+              "alles",
+              "das",
+              "Text",
+              "Auswahl"
+            ]
           }
         ]
       },
       {
         "id": "select_that",
         "_comment": "Use to select a sentence in the current text area. Example: 'select current sentence' (Einen Satz im aktuellen Textbereich auswählen. Beispiel: 'aktuellen Satz auswählen')",
-        "phrases": ["{choice} {selection} auswählen"],
+        "phrases": [
+          "{choice} {selection} auswählen"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuellen", "aktuelles", "ersten", "erstes", "letzten", "letztes", "vorherigen", "vorheriges", "nächsten", "nächstes"]
+            "enum": [
+              "aktuellen",
+              "aktuelles",
+              "ersten",
+              "erstes",
+              "letzten",
+              "letztes",
+              "vorherigen",
+              "vorheriges",
+              "nächsten",
+              "nächstes"
+            ]
           },
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["Wort", "Satz", "Absatz"]
+            "enum": [
+              "Wort",
+              "Satz",
+              "Absatz"
+            ]
           }
         ]
       },
       {
         "id": "select_number_of_words",
         "_comment": "Use to select a number of words relative to cursor position within the current text area. Example: 'select next three words' (Eine bestimmte Anzahl Wörter relativ zur Cursorposition auswählen. Beispiel: 'nächste drei Wörter auswählen')",
-        "phrases": ["{choice} {number} Wörter auswählen", "{choice} {number} Wort auswählen"],
+        "phrases": [
+          "{choice} {number} Wörter auswählen",
+          "{choice} {number} Wort auswählen"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["aktuelle", "erste", "letzte", "vorherige", "nächste"]
+            "enum": [
+              "aktuelle",
+              "erste",
+              "letzte",
+              "vorherige",
+              "nächste"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["eins", "zwei", "drei", "vier", "fünf", "sechs", "sieben", "acht", "neun", "zehn"]
+            "enum": [
+              "eins",
+              "zwei",
+              "drei",
+              "vier",
+              "fünf",
+              "sechs",
+              "sieben",
+              "acht",
+              "neun",
+              "zehn"
+            ]
           }
         ]
       },
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Eine Option oder Auswahl aus einer Liste auswählen. Beispiel: 'Option drei auswählen')",
-        "phrases": ["{number} auswählen, {number} wählen"],
+        "phrases": [
+          "{number} auswählen, {number} wählen"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["eins", "zwei", "drei", "vier", "fünf", "erste", "zweite", "dritte", "vierte", "fünfte"]
+            "enum": [
+              "eins",
+              "zwei",
+              "drei",
+              "vier",
+              "fünf",
+              "erste",
+              "zweite",
+              "dritte",
+              "vierte",
+              "fünfte"
+            ]
           }
         ]
       },
       {
         "id": "select_choice_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Eine Option oder Auswahl aus einer Liste auswählen. Beispiel: 'Option drei auswählen')",
-        "phrases": ["{choice} {number} auswählen", "{number} {choice} auswählen, {number} {choice} wählen"],
+        "phrases": [
+          "{choice} {number} auswählen",
+          "{number} {choice} auswählen, {number} {choice} wählen"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["Auswahl", "Option", "Nummer", "Element"]
+            "enum": [
+              "Auswahl",
+              "Option",
+              "Nummer",
+              "Element"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["eins", "zwei", "drei", "vier", "fünf", "erste", "zweite", "dritte", "vierte", "fünfte"]
+            "enum": [
+              "eins",
+              "zwei",
+              "drei",
+              "vier",
+              "fünf",
+              "erste",
+              "zweite",
+              "dritte",
+              "vierte",
+              "fünfte"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/auto-text.json
+++ b/dictation/commands/en/auto-text.json
@@ -1,38 +1,68 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "insert_template",
         "_comment": "Use to insert a pre-defined template. Example: 'insert soap template'",
-        "phrases": ["insert my {template_name} template", "insert {template_name} template"],
+        "phrases": [
+          "insert my {template_name} template",
+          "insert {template_name} template"
+        ],
         "variables": [
           {
             "key": "template_name",
             "type": "enum",
-            "enum": ["soap", "radiology", "referral", "letter", "patient summary", "h and p", "outpatient note", "progress note", "nursing"]
+            "enum": [
+              "soap",
+              "radiology",
+              "referral",
+              "letter",
+              "patient summary",
+              "h and p",
+              "outpatient note",
+              "progress note",
+              "nursing"
+            ]
           }
         ]
       },
       {
         "id": "insert_exam",
         "_comment": "Use to insert a pre-defined exam template. Example: 'insert normal exam'",
-        "phrases": ["insert {type} exam"],
+        "phrases": [
+          "insert {type} exam"
+        ],
         "variables": [
           {
             "key": "type",
             "type": "enum",
-            "enum": ["normal", "male", "female", "brief", "comprehensive"]
+            "enum": [
+              "normal",
+              "male",
+              "female",
+              "brief",
+              "comprehensive"
+            ]
           }
         ]
       },
       {
         "id": "insert_attestation",
         "_comment": "Use to insert a pre-defined attestation macro. Example: 'insert attestation'",
-        "phrases": ["insert attestation"]
+        "phrases": [
+          "insert attestation"
+        ]
       },
       {
         "id": "insert_signature",
         "_comment": "Use to insert a pre-defined signature macro. Example: 'insert signature' or 'sign the note'",
-        "phrases": ["insert signature", "sign the note"]
+        "phrases": [
+          "insert signature",
+          "sign the note"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/dictation-box.json
+++ b/dictation/commands/en/dictation-box.json
@@ -1,21 +1,36 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "dictation_box",
         "_comment": "Use to control the dictation box if one is available in the application. Example: 'open dictation box'",
-        "phrases": ["{action} dictation box"],
+        "phrases": [
+          "{action} dictation box"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["open", "close", "show", "hide", "anchor", "release"]
+            "enum": [
+              "open",
+              "close",
+              "show",
+              "hide",
+              "anchor",
+              "release"
+            ]
           }
         ]
       },
       {
         "id": "transfer_text",
         "_comment": "Use to transfer text from the dictation box to the cursor location. Example: 'transfer text'",
-        "phrases": ["transfer text"]
+        "phrases": [
+          "transfer text"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/editing.json
+++ b/dictation/commands/en/editing.json
@@ -1,91 +1,156 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "edit_that",
         "_comment": "Use to edit the selected text. Example: 'delete that' or 'undo that'",
-        "phrases": ["{action} that"],
+        "phrases": [
+          "{action} that"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["delete", "scratch", "undo", "redo", "cut", "copy", "paste", "correct"]
+            "enum": [
+              "delete",
+              "scratch",
+              "undo",
+              "redo",
+              "cut",
+              "copy",
+              "paste",
+              "correct"
+            ]
           }
         ]
       },
       {
         "id": "delete_selection",
         "_comment": "Use to delete the text relative to cursor position. Example: 'delete last sentence'",
-        "phrases": ["delete {choice} {location}"],
+        "phrases": [
+          "delete {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "this", "last", "previous", "next"]
+            "enum": [
+              "current",
+              "this",
+              "last",
+              "previous",
+              "next"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["word", "sentence", "paragraph"]
+            "enum": [
+              "word",
+              "sentence",
+              "paragraph"
+            ]
           }
         ]
       },
       {
         "id": "copy_selection",
         "_comment": "Use to copy the text relative to cursor position. Example: 'copy current sentence'",
-        "phrases": ["copy {choice} {location}"],
+        "phrases": [
+          "copy {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "this", "last", "previous", "next"]
+            "enum": [
+              "current",
+              "this",
+              "last",
+              "previous",
+              "next"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["word", "sentence", "paragraph"]
+            "enum": [
+              "word",
+              "sentence",
+              "paragraph"
+            ]
           }
         ]
       },
       {
         "id": "cut_selection",
         "_comment": "Use to cut the text relative to cursor position. Example: 'cut current sentence'",
-        "phrases": ["cut {choice} {location}"],
+        "phrases": [
+          "cut {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "this", "last", "previous", "next"]
+            "enum": [
+              "current",
+              "this",
+              "last",
+              "previous",
+              "next"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["word", "sentence", "paragraph"]
+            "enum": [
+              "word",
+              "sentence",
+              "paragraph"
+            ]
           }
         ]
       },
       {
         "id": "format_selection",
         "_comment": "Use to format the selected text. Example: 'format that bold'",
-        "phrases": ["format that {style}", "format {style}"],
+        "phrases": [
+          "format that {style}",
+          "format {style}"
+        ],
         "variables": [
           {
             "key": "style",
             "type": "enum",
-            "enum": ["bold", "italic", "underline", "normal"]
+            "enum": [
+              "bold",
+              "italic",
+              "underline",
+              "normal"
+            ]
           }
         ]
       },
       {
         "id": "cap_that",
         "_comment": "Use to capitalize the selected text. Example: 'cap that' or 'all caps on'",
-        "phrases": ["all caps {action}"],
+        "phrases": [
+          "all caps {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["on", "off", "that"]
+            "enum": [
+              "on",
+              "off",
+              "that"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/lists.json
+++ b/dictation/commands/en/lists.json
@@ -1,40 +1,79 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "new_list",
         "_comment": "Use to create a new list. Example: 'new list' or 'bullet list'",
-        "phrases": ["{action} list"],
+        "phrases": [
+          "{action} list"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["new", "insert", "start", "end", "bullet", "bulleted", "number", "numbered", "unordered", "ordered"]
+            "enum": [
+              "new",
+              "insert",
+              "start",
+              "end",
+              "bullet",
+              "bulleted",
+              "number",
+              "numbered",
+              "unordered",
+              "ordered"
+            ]
           }
         ]
       },
       {
         "id": "next_item",
         "_comment": "Use to navigate to the next item in the current list. Example: 'next item'",
-        "phrases": ["next {item}", "{item} next"],
+        "phrases": [
+          "next {item}",
+          "{item} next"
+        ],
         "variables": [
           {
             "key": "item",
             "type": "enum",
-            "enum": ["item", "bullet", "number"]
+            "enum": [
+              "item",
+              "bullet",
+              "number"
+            ]
           }
         ]
       },
       {
         "id": "list_number",
         "_comment": "Use to navigate or insert a specific item in a list. Example: 'list item three'",
-        "phrases": ["item {number}", "list item {number}", "list number {number}"],
+        "phrases": [
+          "item {number}",
+          "list item {number}",
+          "list number {number}"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"]
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "six",
+              "seven",
+              "eight",
+              "nine",
+              "ten"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/navigation.json
+++ b/dictation/commands/en/navigation.json
@@ -1,60 +1,104 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "navigate_fields",
         "_comment": "Use to navigate between fields in the current text area. Example: 'next field'",
-        "phrases": ["{choice} {location}"],
+        "phrases": [
+          "{choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["next", "previous", "prior", "first", "last"]
+            "enum": [
+              "next",
+              "previous",
+              "prior",
+              "first",
+              "last"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["field", "section", "control"]
+            "enum": [
+              "field",
+              "section",
+              "control"
+            ]
           }
         ]
       },
       {
         "id": "go_to",
         "_comment": "Use to go to a specific location in the current text area. Example: 'go to end of document'",
-        "phrases": ["go to {choice} of {location}", "{choice} of {location}"],
+        "phrases": [
+          "go to {choice} of {location}",
+          "{choice} of {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["beginning", "start", "end"]
+            "enum": [
+              "beginning",
+              "start",
+              "end"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["line", "paragraph", "document"]
+            "enum": [
+              "line",
+              "paragraph",
+              "document"
+            ]
           }
         ]
       },
       {
         "id": "insert_cursor",
         "_comment": "Use to insert a cursor at a specific location in the current text area. Example: 'insert before current paragraph'",
-        "phrases": ["insert {direction} {choice} {location}"],
+        "phrases": [
+          "insert {direction} {choice} {location}"
+        ],
         "variables": [
           {
             "key": "direction",
             "type": "enum",
-            "enum": ["before", "after"]
+            "enum": [
+              "before",
+              "after"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "first", "last", "previous", "prior", "next"]
+            "enum": [
+              "current",
+              "first",
+              "last",
+              "previous",
+              "prior",
+              "next"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["line", "word", "paragraph", "document"]
+            "enum": [
+              "line",
+              "word",
+              "paragraph",
+              "document"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/select.json
+++ b/dictation/commands/en/select.json
@@ -1,91 +1,175 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
     "commands": [
       {
         "id": "select",
         "_comment": "Use to select all text in current text area. Example: 'select all'",
-        "phrases": ["select {selection}"],
+        "phrases": [
+          "select {selection}"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["all", "that"]
+            "enum": [
+              "all",
+              "that"
+            ]
           }
         ]
       },
       {
         "id": "unselect",
         "_comment": "Use to unselect text selection. Example: 'unselect text'",
-        "phrases": ["unselect {selection}", "deselect {selection}", "clear {selection}"],
+        "phrases": [
+          "unselect {selection}",
+          "deselect {selection}",
+          "clear {selection}"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["all", "that", "text", "selection"]
+            "enum": [
+              "all",
+              "that",
+              "text",
+              "selection"
+            ]
           }
         ]
       },
       {
-        "id": "select_that",  
+        "id": "select_that",
         "_comment": "Use to select a sentence in the current text area. Example: 'select current sentence'",
-        "phrases": ["select {choice} {selection}"],
+        "phrases": [
+          "select {choice} {selection}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "first", "last", "previous", "prior", "next"]
+            "enum": [
+              "current",
+              "first",
+              "last",
+              "previous",
+              "prior",
+              "next"
+            ]
           },
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["word", "sentence", "paragraph"]
+            "enum": [
+              "word",
+              "sentence",
+              "paragraph"
+            ]
           }
         ]
       },
       {
         "id": "select_number_of_words",
         "_comment": "Use to select a number of words relative to cursor position within the current text area. Example: 'select next three words'",
-        "phrases": ["select {choice} {number} words", "select {choice} {number} word"],
+        "phrases": [
+          "select {choice} {number} words",
+          "select {choice} {number} word"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["current", "first", "last", "previous", "prior", "next"]
+            "enum": [
+              "current",
+              "first",
+              "last",
+              "previous",
+              "prior",
+              "next"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"]
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "six",
+              "seven",
+              "eight",
+              "nine",
+              "ten"
+            ]
           }
         ]
       },
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three'",
-        "phrases": ["select {number}, pick {number}, choose {number}"],
+        "phrases": [
+          "select {number}, pick {number}, choose {number}"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["one", "two", "three", "four", "five", "first", "second", "third", "fourth", "fifth"]
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "first",
+              "second",
+              "third",
+              "fourth",
+              "fifth"
+            ]
           }
         ]
       },
       {
         "id": "select_choice_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three'",
-        "phrases": ["select {choice} {number}", "select {number} {choice}, pick {number} {choice}, choose {number} {choice}"],
+        "phrases": [
+          "select {choice} {number}",
+          "select {number} {choice}, pick {number} {choice}, choose {number} {choice}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["choice", "option", "number", "item"]
+            "enum": [
+              "choice",
+              "option",
+              "number",
+              "item"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["one", "two", "three", "four", "five", "first", "second", "third", "fourth", "fifth"]
+            "enum": [
+              "one",
+              "two",
+              "three",
+              "four",
+              "five",
+              "first",
+              "second",
+              "third",
+              "fourth",
+              "fifth"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/en/select.json
+++ b/dictation/commands/en/select.json
@@ -61,7 +61,19 @@
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three'",
-        "phrases": ["select {choice} {number}", "select {number} {choice}, select {number}, pick {number} {choice}, pick {number}, choose {number} {choice}, choose {number}"],
+        "phrases": ["select {number}, pick {number}, choose {number}"],
+        "variables": [
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["one", "two", "three", "four", "five", "first", "second", "third", "fourth", "fifth"]
+          }
+        ]
+      },
+      {
+        "id": "select_choice_number",
+        "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three'",
+        "phrases": ["select {choice} {number}", "select {number} {choice}, pick {number} {choice}, choose {number} {choice}"],
         "variables": [
           {
             "key": "choice",

--- a/dictation/commands/fr/auto-text.json
+++ b/dictation/commands/fr/auto-text.json
@@ -1,38 +1,68 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "insert_template",
         "_comment": "Use to insert a pre-defined template. Example: 'insert soap template' (Insérer un modèle prédéfini. Exemple : 'insérer le modèle soap')",
-        "phrases": ["insérer mon modèle {template_name}", "insérer le modèle {template_name}"],
+        "phrases": [
+          "insérer mon modèle {template_name}",
+          "insérer le modèle {template_name}"
+        ],
         "variables": [
           {
             "key": "template_name",
             "type": "enum",
-            "enum": ["soap", "radiologie", "référence", "lettre", "résumé patient", "h et p", "note ambulatoire", "note d'évolution", "soins infirmiers"]
+            "enum": [
+              "soap",
+              "radiologie",
+              "référence",
+              "lettre",
+              "résumé patient",
+              "h et p",
+              "note ambulatoire",
+              "note d'évolution",
+              "soins infirmiers"
+            ]
           }
         ]
       },
       {
         "id": "insert_exam",
         "_comment": "Use to insert a pre-defined exam template. Example: 'insert normal exam' (Insérer un modèle d'examen prédéfini. Exemple : 'insérer un examen normal')",
-        "phrases": ["insérer un examen {type}"],
+        "phrases": [
+          "insérer un examen {type}"
+        ],
         "variables": [
           {
             "key": "type",
             "type": "enum",
-            "enum": ["normal", "masculin", "féminin", "bref", "complet"]
+            "enum": [
+              "normal",
+              "masculin",
+              "féminin",
+              "bref",
+              "complet"
+            ]
           }
         ]
       },
       {
         "id": "insert_attestation",
         "_comment": "Use to insert a pre-defined attestation macro. Example: 'insert attestation' (Insérer une attestation prédéfinie. Exemple : 'insérer une attestation')",
-        "phrases": ["insérer une attestation"]
+        "phrases": [
+          "insérer une attestation"
+        ]
       },
       {
         "id": "insert_signature",
         "_comment": "Use to insert a pre-defined signature macro. Example: 'insert signature' or 'sign the note' (Insérer une signature prédéfinie. Exemple : 'insérer une signature' ou 'signer la note')",
-        "phrases": ["insérer une signature", "signer la note"]
+        "phrases": [
+          "insérer une signature",
+          "signer la note"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/auto-text.json
+++ b/dictation/commands/fr/auto-text.json
@@ -1,0 +1,38 @@
+{
+    "commands": [
+      {
+        "id": "insert_template",
+        "_comment": "Use to insert a pre-defined template. Example: 'insert soap template' (Insérer un modèle prédéfini. Exemple : 'insérer le modèle soap')",
+        "phrases": ["insérer mon modèle {template_name}", "insérer le modèle {template_name}"],
+        "variables": [
+          {
+            "key": "template_name",
+            "type": "enum",
+            "enum": ["soap", "radiologie", "référence", "lettre", "résumé patient", "h et p", "note ambulatoire", "note d'évolution", "soins infirmiers"]
+          }
+        ]
+      },
+      {
+        "id": "insert_exam",
+        "_comment": "Use to insert a pre-defined exam template. Example: 'insert normal exam' (Insérer un modèle d'examen prédéfini. Exemple : 'insérer un examen normal')",
+        "phrases": ["insérer un examen {type}"],
+        "variables": [
+          {
+            "key": "type",
+            "type": "enum",
+            "enum": ["normal", "masculin", "féminin", "bref", "complet"]
+          }
+        ]
+      },
+      {
+        "id": "insert_attestation",
+        "_comment": "Use to insert a pre-defined attestation macro. Example: 'insert attestation' (Insérer une attestation prédéfinie. Exemple : 'insérer une attestation')",
+        "phrases": ["insérer une attestation"]
+      },
+      {
+        "id": "insert_signature",
+        "_comment": "Use to insert a pre-defined signature macro. Example: 'insert signature' or 'sign the note' (Insérer une signature prédéfinie. Exemple : 'insérer une signature' ou 'signer la note')",
+        "phrases": ["insérer une signature", "signer la note"]
+      }
+    ]
+}

--- a/dictation/commands/fr/dictation-box.json
+++ b/dictation/commands/fr/dictation-box.json
@@ -1,0 +1,21 @@
+{
+    "commands": [
+      {
+        "id": "dictation_box",
+        "_comment": "Use to control the dictation box if one is available in the application. Example: 'open dictation box' (Contrôler la boîte de dictée si elle est disponible dans l'application. Exemple : 'ouvrir la boîte de dictée')",
+        "phrases": ["{action} la boîte de dictée"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["ouvrir", "fermer", "afficher", "masquer", "ancrer", "libérer"]
+          }
+        ]
+      },
+      {
+        "id": "transfer_text",
+        "_comment": "Use to transfer text from the dictation box to the cursor location. Example: 'transfer text' (Transférer le texte de la boîte de dictée vers la position du curseur. Exemple : 'transférer le texte')",
+        "phrases": ["transférer le texte"]
+      }
+    ]
+}

--- a/dictation/commands/fr/dictation-box.json
+++ b/dictation/commands/fr/dictation-box.json
@@ -1,21 +1,36 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "dictation_box",
         "_comment": "Use to control the dictation box if one is available in the application. Example: 'open dictation box' (Contrôler la boîte de dictée si elle est disponible dans l'application. Exemple : 'ouvrir la boîte de dictée')",
-        "phrases": ["{action} la boîte de dictée"],
+        "phrases": [
+          "{action} la boîte de dictée"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["ouvrir", "fermer", "afficher", "masquer", "ancrer", "libérer"]
+            "enum": [
+              "ouvrir",
+              "fermer",
+              "afficher",
+              "masquer",
+              "ancrer",
+              "libérer"
+            ]
           }
         ]
       },
       {
         "id": "transfer_text",
         "_comment": "Use to transfer text from the dictation box to the cursor location. Example: 'transfer text' (Transférer le texte de la boîte de dictée vers la position du curseur. Exemple : 'transférer le texte')",
-        "phrases": ["transférer le texte"]
+        "phrases": [
+          "transférer le texte"
+        ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/editing.json
+++ b/dictation/commands/fr/editing.json
@@ -1,91 +1,165 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "edit_that",
         "_comment": "Use to edit the selected text. Example: 'delete that' or 'undo that' (Modifier le texte sélectionné. Exemple : 'supprimer ça' ou 'annuler ça')",
-        "phrases": ["{action} ça"],
+        "phrases": [
+          "{action} ça"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["supprimer", "effacer", "annuler", "rétablir", "couper", "copier", "coller", "corriger"]
+            "enum": [
+              "supprimer",
+              "effacer",
+              "annuler",
+              "rétablir",
+              "couper",
+              "copier",
+              "coller",
+              "corriger"
+            ]
           }
         ]
       },
       {
         "id": "delete_selection",
         "_comment": "Use to delete the text relative to cursor position. Example: 'delete last sentence' (Supprimer le texte relatif à la position du curseur. Exemple : 'supprimer la dernière phrase')",
-        "phrases": ["supprimer {choice} {location}"],
+        "phrases": [
+          "supprimer {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+            "enum": [
+              "ce",
+              "cette",
+              "dernier",
+              "dernière",
+              "précédent",
+              "précédente",
+              "suivant",
+              "suivante"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["mot", "phrase", "paragraphe"]
+            "enum": [
+              "mot",
+              "phrase",
+              "paragraphe"
+            ]
           }
         ]
       },
       {
         "id": "copy_selection",
         "_comment": "Use to copy the text relative to cursor position. Example: 'copy current sentence' (Copier le texte relatif à la position du curseur. Exemple : 'copier cette phrase')",
-        "phrases": ["copier {choice} {location}"],
+        "phrases": [
+          "copier {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+            "enum": [
+              "ce",
+              "cette",
+              "dernier",
+              "dernière",
+              "précédent",
+              "précédente",
+              "suivant",
+              "suivante"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["mot", "phrase", "paragraphe"]
+            "enum": [
+              "mot",
+              "phrase",
+              "paragraphe"
+            ]
           }
         ]
       },
       {
         "id": "cut_selection",
         "_comment": "Use to cut the text relative to cursor position. Example: 'cut current sentence' (Couper le texte relatif à la position du curseur. Exemple : 'couper cette phrase')",
-        "phrases": ["couper {choice} {location}"],
+        "phrases": [
+          "couper {choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+            "enum": [
+              "ce",
+              "cette",
+              "dernier",
+              "dernière",
+              "précédent",
+              "précédente",
+              "suivant",
+              "suivante"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["mot", "phrase", "paragraphe"]
+            "enum": [
+              "mot",
+              "phrase",
+              "paragraphe"
+            ]
           }
         ]
       },
       {
         "id": "format_selection",
         "_comment": "Use to format the selected text. Example: 'format that bold' (Formater le texte sélectionné. Exemple : 'formater ça en gras')",
-        "phrases": ["formater ça en {style}", "formater en {style}"],
+        "phrases": [
+          "formater ça en {style}",
+          "formater en {style}"
+        ],
         "variables": [
           {
             "key": "style",
             "type": "enum",
-            "enum": ["gras", "italique", "souligné", "normal"]
+            "enum": [
+              "gras",
+              "italique",
+              "souligné",
+              "normal"
+            ]
           }
         ]
       },
       {
         "id": "cap_that",
         "_comment": "Use to capitalize the selected text. Example: 'cap that' or 'all caps on' (Mettre le texte sélectionné en majuscules. Exemple : 'majuscules activer' ou 'majuscules désactiver')",
-        "phrases": ["majuscules {action}"],
+        "phrases": [
+          "majuscules {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["activer", "désactiver", "ça"]
+            "enum": [
+              "activer",
+              "désactiver",
+              "ça"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/editing.json
+++ b/dictation/commands/fr/editing.json
@@ -1,0 +1,91 @@
+{
+    "commands": [
+      {
+        "id": "edit_that",
+        "_comment": "Use to edit the selected text. Example: 'delete that' or 'undo that' (Modifier le texte sélectionné. Exemple : 'supprimer ça' ou 'annuler ça')",
+        "phrases": ["{action} ça"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["supprimer", "effacer", "annuler", "rétablir", "couper", "copier", "coller", "corriger"]
+          }
+        ]
+      },
+      {
+        "id": "delete_selection",
+        "_comment": "Use to delete the text relative to cursor position. Example: 'delete last sentence' (Supprimer le texte relatif à la position du curseur. Exemple : 'supprimer la dernière phrase')",
+        "phrases": ["supprimer {choice} {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["mot", "phrase", "paragraphe"]
+          }
+        ]
+      },
+      {
+        "id": "copy_selection",
+        "_comment": "Use to copy the text relative to cursor position. Example: 'copy current sentence' (Copier le texte relatif à la position du curseur. Exemple : 'copier cette phrase')",
+        "phrases": ["copier {choice} {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["mot", "phrase", "paragraphe"]
+          }
+        ]
+      },
+      {
+        "id": "cut_selection",
+        "_comment": "Use to cut the text relative to cursor position. Example: 'cut current sentence' (Couper le texte relatif à la position du curseur. Exemple : 'couper cette phrase')",
+        "phrases": ["couper {choice} {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["ce", "cette", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["mot", "phrase", "paragraphe"]
+          }
+        ]
+      },
+      {
+        "id": "format_selection",
+        "_comment": "Use to format the selected text. Example: 'format that bold' (Formater le texte sélectionné. Exemple : 'formater ça en gras')",
+        "phrases": ["formater ça en {style}", "formater en {style}"],
+        "variables": [
+          {
+            "key": "style",
+            "type": "enum",
+            "enum": ["gras", "italique", "souligné", "normal"]
+          }
+        ]
+      },
+      {
+        "id": "cap_that",
+        "_comment": "Use to capitalize the selected text. Example: 'cap that' or 'all caps on' (Mettre le texte sélectionné en majuscules. Exemple : 'majuscules activer' ou 'majuscules désactiver')",
+        "phrases": ["majuscules {action}"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["activer", "désactiver", "ça"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/fr/lists.json
+++ b/dictation/commands/fr/lists.json
@@ -1,0 +1,40 @@
+{
+    "commands": [
+      {
+        "id": "new_list",
+        "_comment": "Use to create a new list. Example: 'new list' or 'bullet list' (Créer une nouvelle liste. Exemple : 'nouvelle liste' ou 'liste à puces')",
+        "phrases": ["{action} liste", "liste {action}"],
+        "variables": [
+          {
+            "key": "action",
+            "type": "enum",
+            "enum": ["nouvelle", "insérer", "démarrer", "terminer", "à puces", "numérotée", "non ordonnée", "ordonnée"]
+          }
+        ]
+      },
+      {
+        "id": "next_item",
+        "_comment": "Use to navigate to the next item in the current list. Example: 'next item' (Naviguer vers l'élément suivant dans la liste actuelle. Exemple : 'élément suivant')",
+        "phrases": ["{item} suivant", "suivant {item}"],
+        "variables": [
+          {
+            "key": "item",
+            "type": "enum",
+            "enum": ["élément", "puce", "numéro"]
+          }
+        ]
+      },
+      {
+        "id": "list_number",
+        "_comment": "Use to navigate or insert a specific item in a list. Example: 'list item three' (Naviguer vers un élément spécifique dans une liste. Exemple : 'élément de liste trois')",
+        "phrases": ["élément {number}", "élément de liste {number}", "numéro de liste {number}"],
+        "variables": [
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/fr/lists.json
+++ b/dictation/commands/fr/lists.json
@@ -1,40 +1,78 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "new_list",
         "_comment": "Use to create a new list. Example: 'new list' or 'bullet list' (Créer une nouvelle liste. Exemple : 'nouvelle liste' ou 'liste à puces')",
-        "phrases": ["{action} liste", "liste {action}"],
+        "phrases": [
+          "{action} liste",
+          "liste {action}"
+        ],
         "variables": [
           {
             "key": "action",
             "type": "enum",
-            "enum": ["nouvelle", "insérer", "démarrer", "terminer", "à puces", "numérotée", "non ordonnée", "ordonnée"]
+            "enum": [
+              "nouvelle",
+              "insérer",
+              "démarrer",
+              "terminer",
+              "à puces",
+              "numérotée",
+              "non ordonnée",
+              "ordonnée"
+            ]
           }
         ]
       },
       {
         "id": "next_item",
         "_comment": "Use to navigate to the next item in the current list. Example: 'next item' (Naviguer vers l'élément suivant dans la liste actuelle. Exemple : 'élément suivant')",
-        "phrases": ["{item} suivant", "suivant {item}"],
+        "phrases": [
+          "{item} suivant",
+          "suivant {item}"
+        ],
         "variables": [
           {
             "key": "item",
             "type": "enum",
-            "enum": ["élément", "puce", "numéro"]
+            "enum": [
+              "élément",
+              "puce",
+              "numéro"
+            ]
           }
         ]
       },
       {
         "id": "list_number",
         "_comment": "Use to navigate or insert a specific item in a list. Example: 'list item three' (Naviguer vers un élément spécifique dans une liste. Exemple : 'élément de liste trois')",
-        "phrases": ["élément {number}", "élément de liste {number}", "numéro de liste {number}"],
+        "phrases": [
+          "élément {number}",
+          "élément de liste {number}",
+          "numéro de liste {number}"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix"]
+            "enum": [
+              "un",
+              "deux",
+              "trois",
+              "quatre",
+              "cinq",
+              "six",
+              "sept",
+              "huit",
+              "neuf",
+              "dix"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/navigation.json
+++ b/dictation/commands/fr/navigation.json
@@ -1,60 +1,110 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "navigate_fields",
         "_comment": "Use to navigate between fields in the current text area. Example: 'next field' (Naviguer entre les champs dans la zone de texte actuelle. Exemple : 'champ suivant')",
-        "phrases": ["{choice} {location}"],
+        "phrases": [
+          "{choice} {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["suivant", "suivante", "précédent", "précédente", "premier", "première", "dernier", "dernière"]
+            "enum": [
+              "suivant",
+              "suivante",
+              "précédent",
+              "précédente",
+              "premier",
+              "première",
+              "dernier",
+              "dernière"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["champ", "section", "contrôle"]
+            "enum": [
+              "champ",
+              "section",
+              "contrôle"
+            ]
           }
         ]
       },
       {
         "id": "go_to",
         "_comment": "Use to go to a specific location in the current text area. Example: 'go to end of document' (Aller à un emplacement spécifique dans la zone de texte actuelle. Exemple : 'aller à la fin du document')",
-        "phrases": ["aller au {choice} de {location}", "au {choice} de {location}"],
+        "phrases": [
+          "aller au {choice} de {location}",
+          "au {choice} de {location}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["début", "fin"]
+            "enum": [
+              "début",
+              "fin"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["la ligne", "le paragraphe", "le document"]
+            "enum": [
+              "la ligne",
+              "le paragraphe",
+              "le document"
+            ]
           }
         ]
       },
       {
         "id": "insert_cursor",
         "_comment": "Use to insert a cursor at a specific location in the current text area. Example: 'insert before current paragraph' (Insérer le curseur à un emplacement spécifique. Exemple : 'insérer avant le paragraphe actuel')",
-        "phrases": ["insérer {direction} {choice} {location}"],
+        "phrases": [
+          "insérer {direction} {choice} {location}"
+        ],
         "variables": [
           {
             "key": "direction",
             "type": "enum",
-            "enum": ["avant", "après"]
+            "enum": [
+              "avant",
+              "après"
+            ]
           },
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["le", "la", "le premier", "la première", "le dernier", "la dernière", "le précédent", "la précédente", "le suivant", "la suivante"]
+            "enum": [
+              "le",
+              "la",
+              "le premier",
+              "la première",
+              "le dernier",
+              "la dernière",
+              "le précédent",
+              "la précédente",
+              "le suivant",
+              "la suivante"
+            ]
           },
           {
             "key": "location",
             "type": "enum",
-            "enum": ["ligne", "mot", "paragraphe", "document"]
+            "enum": [
+              "ligne",
+              "mot",
+              "paragraphe",
+              "document"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/navigation.json
+++ b/dictation/commands/fr/navigation.json
@@ -1,0 +1,60 @@
+{
+    "commands": [
+      {
+        "id": "navigate_fields",
+        "_comment": "Use to navigate between fields in the current text area. Example: 'next field' (Naviguer entre les champs dans la zone de texte actuelle. Exemple : 'champ suivant')",
+        "phrases": ["{choice} {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["suivant", "suivante", "précédent", "précédente", "premier", "première", "dernier", "dernière"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["champ", "section", "contrôle"]
+          }
+        ]
+      },
+      {
+        "id": "go_to",
+        "_comment": "Use to go to a specific location in the current text area. Example: 'go to end of document' (Aller à un emplacement spécifique dans la zone de texte actuelle. Exemple : 'aller à la fin du document')",
+        "phrases": ["aller au {choice} de {location}", "au {choice} de {location}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["début", "fin"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["la ligne", "le paragraphe", "le document"]
+          }
+        ]
+      },
+      {
+        "id": "insert_cursor",
+        "_comment": "Use to insert a cursor at a specific location in the current text area. Example: 'insert before current paragraph' (Insérer le curseur à un emplacement spécifique. Exemple : 'insérer avant le paragraphe actuel')",
+        "phrases": ["insérer {direction} {choice} {location}"],
+        "variables": [
+          {
+            "key": "direction",
+            "type": "enum",
+            "enum": ["avant", "après"]
+          },
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["le", "la", "le premier", "la première", "le dernier", "la dernière", "le précédent", "la précédente", "le suivant", "la suivante"]
+          },
+          {
+            "key": "location",
+            "type": "enum",
+            "enum": ["ligne", "mot", "paragraphe", "document"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/fr/select.json
+++ b/dictation/commands/fr/select.json
@@ -1,0 +1,79 @@
+{
+    "commands": [
+      {
+        "id": "select",
+        "_comment": "Use to select all text in current text area. Example: 'select all' (Sélectionner tout le texte dans la zone de texte actuelle. Exemple : 'sélectionner tout')",
+        "phrases": ["sélectionner {selection}"],
+        "variables": [
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["tout", "ça"]
+          }
+        ]
+      },
+      {
+        "id": "unselect",
+        "_comment": "Use to unselect text selection. Example: 'unselect text' (Annuler la sélection de texte. Exemple : 'désélectionner le texte')",
+        "phrases": ["désélectionner {selection}", "décocher {selection}", "effacer {selection}"],
+        "variables": [
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["tout", "ça", "le texte", "la sélection"]
+          }
+        ]
+      },
+      {
+        "id": "select_that",
+        "_comment": "Use to select a sentence in the current text area. Example: 'select current sentence' (Sélectionner une phrase dans la zone de texte actuelle. Exemple : 'sélectionner cette phrase')",
+        "phrases": ["sélectionner {choice} {selection}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["ce", "cette", "premier", "première", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+          },
+          {
+            "key": "selection",
+            "type": "enum",
+            "enum": ["mot", "phrase", "paragraphe"]
+          }
+        ]
+      },
+      {
+        "id": "select_number_of_words",
+        "_comment": "Use to select a number of words relative to cursor position within the current text area. Example: 'select next three words' (Sélectionner un nombre de mots relatif à la position du curseur. Exemple : 'sélectionner les trois mots suivants')",
+        "phrases": ["sélectionner {choice} {number} mots", "sélectionner {choice} {number} mot"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["ce", "cette", "premier", "première", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+          },
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix"]
+          }
+        ]
+      },
+      {
+        "id": "select_number",
+        "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Sélectionner un choix ou une option dans une liste. Exemple : 'sélectionner option trois')",
+        "phrases": ["sélectionner {choice} {number}", "sélectionner {number} {choice}", "sélectionner {number}", "choisir {number} {choice}", "choisir {number}"],
+        "variables": [
+          {
+            "key": "choice",
+            "type": "enum",
+            "enum": ["choix", "option", "numéro", "élément"]
+          },
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["un", "deux", "trois", "quatre", "cinq", "premier", "deuxième", "troisième", "quatrième", "cinquième"]
+          }
+        ]
+      }
+    ]
+}

--- a/dictation/commands/fr/select.json
+++ b/dictation/commands/fr/select.json
@@ -1,91 +1,183 @@
 {
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
     "commands": [
       {
         "id": "select",
         "_comment": "Use to select all text in current text area. Example: 'select all' (Sélectionner tout le texte dans la zone de texte actuelle. Exemple : 'sélectionner tout')",
-        "phrases": ["sélectionner {selection}"],
+        "phrases": [
+          "sélectionner {selection}"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["tout", "ça"]
+            "enum": [
+              "tout",
+              "ça"
+            ]
           }
         ]
       },
       {
         "id": "unselect",
         "_comment": "Use to unselect text selection. Example: 'unselect text' (Annuler la sélection de texte. Exemple : 'désélectionner le texte')",
-        "phrases": ["désélectionner {selection}", "décocher {selection}", "effacer {selection}"],
+        "phrases": [
+          "désélectionner {selection}",
+          "décocher {selection}",
+          "effacer {selection}"
+        ],
         "variables": [
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["tout", "ça", "le texte", "la sélection"]
+            "enum": [
+              "tout",
+              "ça",
+              "le texte",
+              "la sélection"
+            ]
           }
         ]
       },
       {
         "id": "select_that",
         "_comment": "Use to select a sentence in the current text area. Example: 'select current sentence' (Sélectionner une phrase dans la zone de texte actuelle. Exemple : 'sélectionner cette phrase')",
-        "phrases": ["sélectionner {choice} {selection}"],
+        "phrases": [
+          "sélectionner {choice} {selection}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["ce", "cette", "premier", "première", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+            "enum": [
+              "ce",
+              "cette",
+              "premier",
+              "première",
+              "dernier",
+              "dernière",
+              "précédent",
+              "précédente",
+              "suivant",
+              "suivante"
+            ]
           },
           {
             "key": "selection",
             "type": "enum",
-            "enum": ["mot", "phrase", "paragraphe"]
+            "enum": [
+              "mot",
+              "phrase",
+              "paragraphe"
+            ]
           }
         ]
       },
       {
         "id": "select_number_of_words",
         "_comment": "Use to select a number of words relative to cursor position within the current text area. Example: 'select next three words' (Sélectionner un nombre de mots relatif à la position du curseur. Exemple : 'sélectionner les trois mots suivants')",
-        "phrases": ["sélectionner {choice} {number} mots", "sélectionner {choice} {number} mot"],
+        "phrases": [
+          "sélectionner {choice} {number} mots",
+          "sélectionner {choice} {number} mot"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["ce", "cette", "premier", "première", "dernier", "dernière", "précédent", "précédente", "suivant", "suivante"]
+            "enum": [
+              "ce",
+              "cette",
+              "premier",
+              "première",
+              "dernier",
+              "dernière",
+              "précédent",
+              "précédente",
+              "suivant",
+              "suivante"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["un", "deux", "trois", "quatre", "cinq", "six", "sept", "huit", "neuf", "dix"]
+            "enum": [
+              "un",
+              "deux",
+              "trois",
+              "quatre",
+              "cinq",
+              "six",
+              "sept",
+              "huit",
+              "neuf",
+              "dix"
+            ]
           }
         ]
       },
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Sélectionner un choix ou une option dans une liste. Exemple : 'sélectionner option trois')",
-        "phrases": ["sélectionner {number}, choisir {number}"],
+        "phrases": [
+          "sélectionner {number}, choisir {number}"
+        ],
         "variables": [
           {
             "key": "number",
             "type": "enum",
-            "enum": ["un", "deux", "trois", "quatre", "cinq", "premier", "deuxième", "troisième", "quatrième", "cinquième"]
+            "enum": [
+              "un",
+              "deux",
+              "trois",
+              "quatre",
+              "cinq",
+              "premier",
+              "deuxième",
+              "troisième",
+              "quatrième",
+              "cinquième"
+            ]
           }
         ]
       },
       {
         "id": "select_choice_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Sélectionner un choix ou une option dans une liste. Exemple : 'sélectionner option trois')",
-        "phrases": ["sélectionner {choice} {number}", "sélectionner {number} {choice}, choisir {number} {choice}"],
+        "phrases": [
+          "sélectionner {choice} {number}",
+          "sélectionner {number} {choice}, choisir {number} {choice}"
+        ],
         "variables": [
           {
             "key": "choice",
             "type": "enum",
-            "enum": ["choix", "option", "numéro", "élément"]
+            "enum": [
+              "choix",
+              "option",
+              "numéro",
+              "élément"
+            ]
           },
           {
             "key": "number",
             "type": "enum",
-            "enum": ["un", "deux", "trois", "quatre", "cinq", "premier", "deuxième", "troisième", "quatrième", "cinquième"]
+            "enum": [
+              "un",
+              "deux",
+              "trois",
+              "quatre",
+              "cinq",
+              "premier",
+              "deuxième",
+              "troisième",
+              "quatrième",
+              "cinquième"
+            ]
           }
         ]
       }
     ]
+  }
 }

--- a/dictation/commands/fr/select.json
+++ b/dictation/commands/fr/select.json
@@ -61,7 +61,19 @@
       {
         "id": "select_number",
         "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Sélectionner un choix ou une option dans une liste. Exemple : 'sélectionner option trois')",
-        "phrases": ["sélectionner {choice} {number}", "sélectionner {number} {choice}", "sélectionner {number}", "choisir {number} {choice}", "choisir {number}"],
+        "phrases": ["sélectionner {number}, choisir {number}"],
+        "variables": [
+          {
+            "key": "number",
+            "type": "enum",
+            "enum": ["un", "deux", "trois", "quatre", "cinq", "premier", "deuxième", "troisième", "quatrième", "cinquième"]
+          }
+        ]
+      },
+      {
+        "id": "select_choice_number",
+        "_comment": "Use to select a choice or option from a list of choices or options. Example: 'select option three' (Sélectionner un choix ou une option dans une liste. Exemple : 'sélectionner option trois')",
+        "phrases": ["sélectionner {choice} {number}", "sélectionner {number} {choice}, choisir {number} {choice}"],
         "variables": [
           {
             "key": "choice",

--- a/dictation/replacements/README.md
+++ b/dictation/replacements/README.md
@@ -1,0 +1,57 @@
+# Replacement Rules 
+
+This folder contains example transcript replacement catalogs for use with Corti Symphony. Each file defines a set of `replacements` that can be registered in the `/transcribe` WebSocket configuration to rewrite final transcript text after speech recognition.
+
+## Directory Layout
+
+- `en/` — English replacement catalogs
+  - `numbered-list.json` — Convert spoken list starters into numbered list prefixes, using ordinal adverb form (e.g., "firstly") to not conflict with common general dictation words (e.g., "first")
+  - `roman-numerals.json` — Convert spoken "Roman numeral ..." phrases into Roman numerals
+- `de/` — German replacement catalogs
+  - `numbered-list.json` — Convert spoken list starters into numbered list prefixes, using ordinal adverb form to not conflict with common general dictation words 
+  - `roman-numerals.json` — Convert spoken "Römisch ..." phrases into Roman numerals
+- `fr/` — French replacement catalogs
+  - `numbered-lists.json` — Convert spoken list starters into numbered list prefixes, using ordinal adverb form to not conflict with common general dictation words 
+  - `roman-numerals.json` — Convert spoken "Numéro romain ..." phrases into Roman numerals
+
+## Using Replacements in `/transcribe`
+
+Replacements are provided in the WebSocket `config` message under `configuration.replacements` as an array of replacement objects.
+
+Each replacement object contains:
+
+- `find` (string, required): Speech-to-text output to replace.
+- `replace` (string, required): Replacement text to use in final transcript output.
+
+Replacements can target single words, acronyms, or multi-word phrases. They are applied to final transcript text output, and the API currently enforces a maximum of 1,000 replacement items per configuration.
+
+The example JSON files in this folder are complete `config` payloads. You can either send them as-is or copy only the `configuration.replacements` array into a larger `/transcribe` configuration.
+
+### Example Configuration
+
+```json
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
+    "spokenPunctuation": true,
+    "replacements": [
+      { "find": "firstly", "replace": "1." },
+      { "find": "secondly", "replace": "2." },
+      { "find": "Roman numeral four", "replace": "iv" },
+      { "find": "BID", "replace": "twice daily" }
+    ]
+  }
+}
+```
+
+## Typical Use Cases
+
+- Convert spoken list markers into numbered lists
+- Normalize Roman numerals for exams, classifications, or outlines
+- Expand or restyle abbreviations, acronyms, or preferred phrases in the final transcript
+
+## See Also
+
+- [Transcript replacements](https://docs.corti.ai/stt/replacements)
+- [Real-time stateless dictation — `/transcribe` configuration](https://docs.corti.ai/api-reference/transcribe)

--- a/dictation/replacements/de/numbered-list.json
+++ b/dictation/replacements/de/numbered-list.json
@@ -1,0 +1,18 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
+    "replacements": [
+      { "find": "Erstens", "replace": "1." },
+      { "find": "Zweitens", "replace": "2." },
+      { "find": "Drittens", "replace": "3." },
+      { "find": "Viertens", "replace": "4." },
+      { "find": "Fünftens", "replace": "5." },
+      { "find": "Sechstens", "replace": "6." },
+      { "find": "Siebtens", "replace": "7." },
+      { "find": "Achtens", "replace": "8." },
+      { "find": "Neuntens", "replace": "9." },
+      { "find": "Zehntens", "replace": "10." }
+    ]
+  }
+}

--- a/dictation/replacements/de/roman-numerals.json
+++ b/dictation/replacements/de/roman-numerals.json
@@ -1,0 +1,20 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "de",
+    "replacements": [
+      { "find": "Römisch eins", "replace": "i" },
+      { "find": "Römisch zwei", "replace": "ii" },
+      { "find": "Römisch drei", "replace": "iii" },
+      { "find": "Römisch vier", "replace": "iv" },
+      { "find": "Römisch fünf", "replace": "v" },
+      { "find": "Römisch sechs", "replace": "vi" },
+      { "find": "Römisch sieben", "replace": "vii" },
+      { "find": "Römisch acht", "replace": "viii" },
+      { "find": "Römisch neun", "replace": "ix" },
+      { "find": "Römisch zehn", "replace": "x" },
+      { "find": "Römisch elf", "replace": "xi" },
+      { "find": "Römisch zwölf", "replace": "xii" }
+    ]
+  }
+}

--- a/dictation/replacements/en/abbreviations.json
+++ b/dictation/replacements/en/abbreviations.json
@@ -1,0 +1,17 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
+    "replacements": [
+      { "find": "QD", "replace": "once daily" },
+      { "find": "BID", "replace": "twice daily" },
+      { "find": "TID", "replace": "three times daily" },
+      { "find": "QID", "replace": "four times daily" },
+      { "find": "QHS", "replace": "at bedtime" },
+      { "find": "QOD", "replace": "every other day" },
+      { "find": "PRN", "replace": "as needed" },
+      { "find": "STAT", "replace": "immediately" },
+      { "find": "PO", "replace": "by mouth" }
+    ]
+  }
+}

--- a/dictation/replacements/en/abbreviations.json
+++ b/dictation/replacements/en/abbreviations.json
@@ -10,7 +10,6 @@
       { "find": "QHS", "replace": "at bedtime" },
       { "find": "QOD", "replace": "every other day" },
       { "find": "PRN", "replace": "as needed" },
-      { "find": "STAT", "replace": "immediately" },
       { "find": "PO", "replace": "by mouth" }
     ]
   }

--- a/dictation/replacements/en/numbered-list.json
+++ b/dictation/replacements/en/numbered-list.json
@@ -1,0 +1,18 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
+    "replacements": [
+      { "find": "firstly", "replace": "1." },
+      { "find": "secondly", "replace": "2." },
+      { "find": "thirdly", "replace": "3." },
+      { "find": "fourthly", "replace": "4." },
+      { "find": "fifthly", "replace": "5." },
+      { "find": "sixthly", "replace": "6." },
+      { "find": "seventhly", "replace": "7." },
+      { "find": "eighthly", "replace": "8." },
+      { "find": "ninthly", "replace": "9." },
+      { "find": "tenthly", "replace": "10." }
+    ]
+  }
+}

--- a/dictation/replacements/en/roman-numerals.json
+++ b/dictation/replacements/en/roman-numerals.json
@@ -1,0 +1,20 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "en",
+    "replacements": [
+      { "find": "Roman numeral one", "replace": "i" },
+      { "find": "Roman numeral two", "replace": "ii" },
+      { "find": "Roman numeral three", "replace": "iii" },
+      { "find": "Roman numeral four", "replace": "iv" },
+      { "find": "Roman numeral five", "replace": "v" },
+      { "find": "Roman numeral six", "replace": "vi" },
+      { "find": "Roman numeral seven", "replace": "vii" },
+      { "find": "Roman numeral eight", "replace": "viii" },
+      { "find": "Roman numeral nine", "replace": "ix" },
+      { "find": "Roman numeral ten", "replace": "x" },
+      { "find": "Roman numeral eleven", "replace": "xi" },
+      { "find": "Roman numeral twelve", "replace": "xii" }
+    ]
+  }
+}

--- a/dictation/replacements/fr/numbered-lists.json
+++ b/dictation/replacements/fr/numbered-lists.json
@@ -1,0 +1,18 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
+    "replacements": [
+      { "find": "Premièrement", "replace": "1." },
+      { "find": "Deuxièmement", "replace": "2." },
+      { "find": "Troisièmement", "replace": "3." },
+      { "find": "Quatrièmement", "replace": "4." },
+      { "find": "Cinquièmement", "replace": "5." },
+      { "find": "Sixièmement", "replace": "6." },
+      { "find": "Septièmement", "replace": "7." },
+      { "find": "Huitièmement", "replace": "8." },
+      { "find": "Neuvièmement", "replace": "9." },
+      { "find": "Dixièmement", "replace": "10." }
+    ]
+  }
+}

--- a/dictation/replacements/fr/roman-numerals.json
+++ b/dictation/replacements/fr/roman-numerals.json
@@ -1,0 +1,20 @@
+{
+  "type": "config",
+  "configuration": {
+    "primaryLanguage": "fr",
+    "replacements": [
+      { "find": "Romain un", "replace": "i" },
+      { "find": "Romain deux", "replace": "ii" },
+      { "find": "Romain trois", "replace": "iii" },
+      { "find": "Romain quatre", "replace": "iv" },
+      { "find": "Romain cinq", "replace": "v" },
+      { "find": "Romain six", "replace": "vi" },
+      { "find": "Romain sept", "replace": "vii" },
+      { "find": "Romain huit", "replace": "viii" },
+      { "find": "Romain neuf", "replace": "ix" },
+      { "find": "Romain dix", "replace": "x" },
+      { "find": "Romain onze", "replace": "xi" },
+      { "find": "Romain douze", "replace": "xii" }
+    ]
+  }
+}


### PR DESCRIPTION
Add translation of English commands for Germand and French. 
Update command examples to be full (valid) config objects. 
Add replacements config for English, French, German - roman numerals and numbered lists. 