### PR TITLE
feat(embedded): update examples for embedded-web@v0.3.1

### DIFF
--- a/embedded-assistant/react/basic-example/README.md
+++ b/embedded-assistant/react/basic-example/README.md
@@ -5,9 +5,10 @@ Minimal React example showing how to integrate the Corti Embedded Assistant.
 ## What This Example Does
 
 1. **Authenticates** with Corti using ROPC flow via backend
-2. **Creates an interaction** with encounter details
-3. **Navigates** to the session view
-4. **Handles** events and errors from the embedded component
+2. **Configures** app-level UI and interaction options using the current Embedded API
+3. **Creates an interaction** with encounter details
+4. **Navigates** to the session view
+5. **Handles** events and errors from the embedded component
 
 ## What This Example Doesn't Cover
 
@@ -32,7 +33,7 @@ npm install
 npm run dev
 ```
 
-Opens on `http://localhost:5173` with backend at `http://localhost:3000`.
+Opens on `http://localhost:8015` with backend at `http://localhost:8013`.
 
 ## Core Files
 
@@ -41,7 +42,7 @@ Opens on `http://localhost:5173` with backend at `http://localhost:3000`.
 - **[server.ts](server.ts)** - Express HTTP server with CORS for Vite dev server:
   - **Config endpoint** (`/api/config`) - Returns `baseUrl` constructed from `CORTI_ENVIRONMENT`
   - **Authentication endpoint** (`/api/auth`) - Implements ROPC flow using `@corti/sdk` to exchange user credentials for OAuth tokens
-  - Runs on port 3000, separate from Vite dev server
+  - Runs on port 8013, separate from Vite dev server on port 8015
 
 ### Frontend
 
@@ -54,6 +55,8 @@ Opens on `http://localhost:5173` with backend at `http://localhost:3000`.
   - **Component setup** - Uses `CortiEmbeddedReact` component with ref
   - **API access** - Gets API via `useCortiEmbeddedApi()` hook
   - **Authentication** - Calls `api.auth()` in `onReady` handler
+  - **App configuration** - Calls `api.configureApp()` for app-level UI options
+  - **Interaction options** - Calls `api.setInteractionOptions()` before creating the interaction
   - **Interaction creation** - Creates encounter and navigates to session
   - **Event handling** - Handles `onReady`, `onEvent`, and `onError` callbacks
 
@@ -76,6 +79,25 @@ const api = useCortiEmbeddedApi(cortiRef);
 
 // In onReady callback:
 await api.auth(credentials);
+await api.configureApp({
+  ui: {
+    interactionTitle: true,
+    aiChat: true,
+    documentFeedback: true,
+    navigation: true,
+  },
+});
+await api.setInteractionOptions({
+  mode: {
+    fallback: "in-person",
+    options: ["in-person", "virtual"],
+  },
+  documents: {
+    actions: {
+      sync: true,
+    },
+  },
+});
 const interaction = await api.createInteraction({ encounter: {...} });
 await api.navigate(`/session/${interaction.id}`);
 ```

--- a/embedded-assistant/react/basic-example/package-lock.json
+++ b/embedded-assistant/react/basic-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "embedded-assistant-react-basic",
       "version": "0.0.1",
       "dependencies": {
-        "@corti/embedded-web": "^0.1.1",
+        "@corti/embedded-web": "^0.3.1",
         "@corti/sdk": "^0.10.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -313,13 +313,12 @@
       }
     },
     "node_modules/@corti/embedded-web": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.1.1.tgz",
-      "integrity": "sha512-v0wTP/h3NlnIQEd2jwJ8fShus6oMJIyDkILepchCXHTw+XFIoj9ttE67Q/GvtQtuqugkTlfLIOGHxKpmgEucxQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.3.1.tgz",
+      "integrity": "sha512-klRYRvaxpeIXkqq4e4FYF5/Zoq7zwCkQVKICw3H3V1NpSpxcYidFq2TQ9AENezpV63obS3eoAWZuRw2f/tNNBA==",
       "license": "MIT",
       "dependencies": {
         "@corti/sdk": "^0.5.0",
-        "@lit/react": "^1.0.8",
         "lit": "^3.1.4"
       },
       "peerDependencies": {
@@ -848,15 +847,6 @@
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@lit/react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
-      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "@types/react": "17 || 18 || 19"
-      }
-    },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
@@ -1374,6 +1364,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1808,6 +1799,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/embedded-assistant/react/basic-example/package.json
+++ b/embedded-assistant/react/basic-example/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@corti/embedded-web": "^0.1.1",
+    "@corti/embedded-web": "^0.3.1",
     "@corti/sdk": "^0.10.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/embedded-assistant/react/basic-example/server.ts
+++ b/embedded-assistant/react/basic-example/server.ts
@@ -7,15 +7,13 @@ import { CortiAuth } from "@corti/sdk";
 config();
 
 const app = express();
-const PORT = 3000;
+const PORT = Number(process.env.PORT ?? 8013);
+const CLIENT_ORIGIN = process.env.CLIENT_ORIGIN ?? "http://localhost:8015";
 
 // Enable CORS for Vite dev server
-// Note: Vite defaults to port 5173. If that port is in use, Vite will pick
-// the next available port (e.g. 5174) and all API calls will fail with CORS
-// errors. Update this origin to match the port shown in Vite's startup output.
 app.use(
   cors({
-    origin: ["http://localhost:5173"],
+    origin: [CLIENT_ORIGIN],
     credentials: true,
   }),
 );

--- a/embedded-assistant/react/basic-example/src/components/EmbeddedAssistant.tsx
+++ b/embedded-assistant/react/basic-example/src/components/EmbeddedAssistant.tsx
@@ -34,6 +34,27 @@ export function EmbeddedAssistant({
       setStatus({ message: "Authenticating...", type: "loading" });
       await api.auth(authData);
 
+      await api.configureApp({
+        ui: {
+          interactionTitle: true,
+          aiChat: true,
+          documentFeedback: true,
+          navigation: true,
+        },
+      });
+
+      await api.setInteractionOptions({
+        mode: {
+          fallback: "in-person",
+          options: ["in-person", "virtual"],
+        },
+        documents: {
+          actions: {
+            sync: true,
+          },
+        },
+      });
+
       setStatus({ message: "Creating interaction...", type: "loading" });
       const interaction = await api.createInteraction({
         assignedUserId: null,

--- a/embedded-assistant/react/basic-example/vite.config.ts
+++ b/embedded-assistant/react/basic-example/vite.config.ts
@@ -5,10 +5,11 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: 8015,
+    strictPort: true,
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: process.env.API_BASE_URL ?? "http://localhost:8013",
         changeOrigin: true,
       },
     },

--- a/embedded-assistant/vanilla-ts/basic-example/README.md
+++ b/embedded-assistant/vanilla-ts/basic-example/README.md
@@ -5,9 +5,10 @@ Minimal vanilla TypeScript example showing how to integrate the Corti Embedded A
 ## What This Example Does
 
 1. **Authenticates** with Corti using ROPC flow via backend
-2. **Creates an interaction** with encounter details
-3. **Navigates** to the session view
-4. **Handles** events and errors from the embedded component
+2. **Configures** app-level UI and interaction options using the current Embedded API
+3. **Creates an interaction** with encounter details
+4. **Navigates** to the session view
+5. **Handles** events and errors from the embedded component
 
 ## What This Example Doesn't Cover
 
@@ -32,7 +33,7 @@ npm install
 npm run dev
 ```
 
-This starts both the TypeScript compiler in watch mode and the server. Opens on `http://localhost:3000` with:
+This starts both the TypeScript compiler in watch mode and the server. Opens on `http://localhost:8011` with:
 
 - Auto-compilation of TypeScript files on changes
 - Auto-restart of server on file changes
@@ -47,7 +48,7 @@ This starts both the TypeScript compiler in watch mode and the server. Opens on 
   - **Library endpoint** (`/lib/embedded-web`) - Serves `@corti/embedded-web` bundle from `node_modules`
   - **Authentication endpoint** (`/api/auth`) - Implements ROPC flow using `@corti/sdk` to exchange user credentials for OAuth tokens
   - Auto-restarts on changes to `server.ts`, `index.html`, or `.env` (via `tsx watch`)
-  - Runs on port 3000
+  - Runs on port 8011
 
 ### Frontend
 
@@ -59,8 +60,10 @@ This starts both the TypeScript compiler in watch mode and the server. Opens on 
 
 - **[public/app.ts](public/app.ts)** - Main application logic:
   - **Component access** - Gets `<corti-embedded>` element by ID and casts to API type
-  - **Event listener** - Listens for `ready` event (with `{ once: true }` option)
+  - **Readiness check** - Waits for the `embedded.ready` event before starting API calls
   - **Authentication** - Calls `corti.auth()` with credentials from `/api/auth`
+  - **App configuration** - Calls `corti.configureApp()` for app-level UI options
+  - **Interaction options** - Calls `corti.setInteractionOptions()` before creating the interaction
   - **Interaction creation** - Creates encounter with `corti.createInteraction()`
   - **Navigation** - Calls `corti.navigate()` to session view
   - **Error handling** - Listens for `error` events and displays status
@@ -84,12 +87,33 @@ This starts both the TypeScript compiler in watch mode and the server. Opens on 
 // Get embedded element reference
 const corti = document.getElementById("assistant") as CortiEmbeddedElement;
 
-// Listen for ready event (once)
-corti.addEventListener("ready", async () => {
-  await corti.auth(credentials);
-  const interaction = await corti.createInteraction({ encounter: {...} });
-  await corti.navigate(`/session/${interaction.id}`);
-}, { once: true });
+const readyPromise = waitForReady(corti);
+const authPromise = fetch("/api/auth").then((response) => response.json());
+
+const [, credentials] = await Promise.all([readyPromise, authPromise]);
+
+await corti.auth(credentials);
+await corti.configureApp({
+  ui: {
+    interactionTitle: true,
+    aiChat: true,
+    documentFeedback: true,
+    navigation: true,
+  },
+});
+await corti.setInteractionOptions({
+  mode: {
+    fallback: "in-person",
+    options: ["in-person", "virtual"],
+  },
+  documents: {
+    actions: {
+      sync: true,
+    },
+  },
+});
+const interaction = await corti.createInteraction({ encounter: {...} });
+await corti.navigate(`/session/${interaction.id}`);
 
 // Handle errors
 corti.addEventListener("error", (event: any) => {

--- a/embedded-assistant/vanilla-ts/basic-example/package-lock.json
+++ b/embedded-assistant/vanilla-ts/basic-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "embedded-assistant-vanilla-basic",
       "version": "0.0.1",
       "dependencies": {
-        "@corti/embedded-web": "^0.1.1",
+        "@corti/embedded-web": "^0.3.1",
         "@corti/sdk": "^0.10.1"
       },
       "devDependencies": {
@@ -24,13 +24,12 @@
       }
     },
     "node_modules/@corti/embedded-web": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.1.1.tgz",
-      "integrity": "sha512-v0wTP/h3NlnIQEd2jwJ8fShus6oMJIyDkILepchCXHTw+XFIoj9ttE67Q/GvtQtuqugkTlfLIOGHxKpmgEucxQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.3.1.tgz",
+      "integrity": "sha512-klRYRvaxpeIXkqq4e4FYF5/Zoq7zwCkQVKICw3H3V1NpSpxcYidFq2TQ9AENezpV63obS3eoAWZuRw2f/tNNBA==",
       "license": "MIT",
       "dependencies": {
         "@corti/sdk": "^0.5.0",
-        "@lit/react": "^1.0.8",
         "lit": "^3.1.4"
       },
       "peerDependencies": {
@@ -509,15 +508,6 @@
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@lit/react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
-      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "@types/react": "17 || 18 || 19"
-      }
-    },
     "node_modules/@lit/reactive-element": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
@@ -621,16 +611,6 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.2.2"
-      }
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -931,12 +911,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/embedded-assistant/vanilla-ts/basic-example/package.json
+++ b/embedded-assistant/vanilla-ts/basic-example/package.json
@@ -10,7 +10,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@corti/embedded-web": "^0.1.1",
+    "@corti/embedded-web": "^0.3.1",
     "@corti/sdk": "^0.10.1"
   },
   "devDependencies": {

--- a/embedded-assistant/vanilla-ts/basic-example/public/app.ts
+++ b/embedded-assistant/vanilla-ts/basic-example/public/app.ts
@@ -1,12 +1,27 @@
 import "@corti/embedded-web";
-import type { CortiEmbeddedAPI } from "@corti/embedded-web/types";
+import type { CortiEmbeddedAPI } from "@corti/embedded-web";
 
 type CortiEmbeddedElement = HTMLElement & CortiEmbeddedAPI;
 
-async function main() {
-  const authRes = await fetch("/api/auth");
-  const authData = await authRes.json();
+function waitForReady(corti: CortiEmbeddedElement) {
+  return new Promise<void>((resolve) => {
+    corti.addEventListener("embedded.ready", () => resolve(), { once: true });
+  });
+}
 
+async function fetchAuthData() {
+  const authRes = await fetch("/api/auth");
+  if (!authRes.ok) {
+    const errorBody = await authRes.json().catch(() => null);
+    throw new Error(
+      errorBody?.message ?? `Authentication failed (${authRes.status})`,
+    );
+  }
+
+  return authRes.json();
+}
+
+async function main() {
   const statusDiv = document.getElementById("status");
   function setStatus(msg: string, type: "loading" | "success" | "error") {
     if (statusDiv) {
@@ -30,36 +45,57 @@ async function main() {
       setStatus(`Error: ${event.detail?.message || "Unknown error"}`, "error");
     });
 
-    // Function to initialize the session
-    const initializeSession = async () => {
-      try {
-        setStatus("Authenticating...", "loading");
-        await corti.auth(authData);
+    const readyPromise = waitForReady(corti);
+    const authPromise = fetchAuthData();
 
-        setStatus("Creating interaction...", "loading");
-        const interaction = await corti.createInteraction({
-          assignedUserId: null,
-          encounter: {
-            identifier: `encounter-${Date.now()}`,
-            status: "planned",
-            type: "first_consultation",
-            period: { startedAt: new Date().toISOString() },
+    try {
+      setStatus("Preparing session...", "loading");
+      const [, authData] = await Promise.all([readyPromise, authPromise]);
+
+      setStatus("Authenticating...", "loading");
+      await corti.auth(authData);
+
+      await corti.configureApp({
+        ui: {
+          interactionTitle: true,
+          aiChat: true,
+          documentFeedback: true,
+          navigation: true,
+        },
+      });
+
+      await corti.setInteractionOptions({
+        mode: {
+          fallback: "in-person",
+          options: ["in-person", "virtual"],
+        },
+        documents: {
+          actions: {
+            sync: true,
           },
-        });
+        },
+      });
 
-        setStatus("Starting session...", "loading");
-        await corti.navigate(`/session/${interaction.id}`);
-        setStatus("Session started!", "success");
-      } catch (err) {
-        setStatus(
-          `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-          "error",
-        );
-      }
-    };
+      setStatus("Creating interaction...", "loading");
+      const interaction = await corti.createInteraction({
+        assignedUserId: null,
+        encounter: {
+          identifier: `encounter-${Date.now()}`,
+          status: "planned",
+          type: "first_consultation",
+          period: { startedAt: new Date().toISOString() },
+        },
+      });
 
-    // Wait for ready event (only once)
-    corti.addEventListener("ready", initializeSession, { once: true });
+      setStatus("Starting session...", "loading");
+      await corti.navigate(`/session/${interaction.id}`);
+      setStatus("Session started!", "success");
+    } catch (err) {
+      setStatus(
+        `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
+        "error",
+      );
+    }
   } catch (err) {
     setStatus(
       `Error: ${err instanceof Error ? err.message : "Unknown error"}`,

--- a/embedded-assistant/vanilla-ts/basic-example/server.ts
+++ b/embedded-assistant/vanilla-ts/basic-example/server.ts
@@ -9,12 +9,12 @@ import { CortiAuth } from "@corti/sdk";
 config();
 
 const app = express();
-const PORT = 3000;
+const PORT = Number(process.env.PORT ?? 8011);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 app.use(
   cors({
-    origin: ["http://localhost:3000"],
+    origin: ["http://localhost:8011"],
     credentials: true,
   }),
 );


### PR DESCRIPTION
## Summary

- Update embedded assistant vanilla and React examples to `@corti/embedded-web@^0.3.1`
- Migrate examples to the new `configureApp()` and `setInteractionOptions()` configuration flow
- Start auth fetching and embedded readiness waiting independently in the vanilla example, using the documented `embedded.ready` event
- Move embedded example dev servers to unique `80xx` ports to avoid collisions across products: 
  - Vanilla: `8011`
  - React backend: `8013`
  - React frontend: `8015`
- Refresh README instructions and API flow snippets for the new config structure and ports

To be released together with [the updated guide](https://github.com/corticph/docs_corti/pull/725) in docs.