### PR TITLE
feat(embedded): update examples for latest embedded component

### DIFF
--- a/embedded-assistant/react/basic-example/README.md
+++ b/embedded-assistant/react/basic-example/README.md
@@ -7,14 +7,14 @@ Minimal React example showing how to integrate the Corti Embedded Assistant.
 1. **Authenticates** with Corti using ROPC flow via backend
 2. **Configures** app-level UI and interaction options using the current Embedded API
 3. **Creates an interaction** with encounter details
-4. **Navigates** to the session view
-5. **Handles** events and errors from the embedded component
+4. **Navigates** to the session view and waits for `interaction.loaded`
+5. **Handles** lifecycle timeouts, retry, events, and errors from the embedded component
 
 ## What This Example Doesn't Cover
 
 - Customisation
 - Advanced event handling
-- Production error handling patterns
+- Production observability patterns
 - State management
 
 ## Quick Start
@@ -57,7 +57,8 @@ Opens on `http://localhost:8015` with backend at `http://localhost:8013`.
   - **Authentication** - Calls `api.auth()` in `onReady` handler
   - **App configuration** - Calls `api.configureApp()` for app-level UI options
   - **Interaction options** - Calls `api.setInteractionOptions()` before creating the interaction
-  - **Interaction creation** - Creates encounter and navigates to session
+  - **Interaction creation** - Creates encounter and navigates to session while the embed is hidden
+  - **Lifecycle recovery** - Adds timeouts for `embedded.ready` and `interaction.loaded`, then remounts on retry
   - **Event handling** - Handles `onReady`, `onEvent`, and `onError` callbacks
 
 - **[src/lib/auth.ts](src/lib/auth.ts)** - Backend communication helpers:
@@ -78,6 +79,9 @@ Opens on `http://localhost:8015` with backend at `http://localhost:8013`.
 const api = useCortiEmbeddedApi(cortiRef);
 
 // In onReady callback:
+const corti = cortiRef.current;
+corti.hide();
+
 await api.auth(credentials);
 await api.configureApp({
   ui: {
@@ -99,5 +103,8 @@ await api.setInteractionOptions({
   },
 });
 const interaction = await api.createInteraction({ encounter: {...} });
-await api.navigate(`/session/${interaction.id}`);
+await waitForInteractionLoaded(corti, () =>
+  api.navigate({ path: `/session/${interaction.id}` }),
+);
+corti.show();
 ```

--- a/embedded-assistant/react/basic-example/package-lock.json
+++ b/embedded-assistant/react/basic-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "embedded-assistant-react-basic",
       "version": "0.0.1",
       "dependencies": {
-        "@corti/embedded-web": "^0.3.1",
+        "@corti/embedded-web": "^1.0.0",
         "@corti/sdk": "^0.10.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@corti/embedded-web": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.3.1.tgz",
-      "integrity": "sha512-klRYRvaxpeIXkqq4e4FYF5/Zoq7zwCkQVKICw3H3V1NpSpxcYidFq2TQ9AENezpV63obS3eoAWZuRw2f/tNNBA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-1.0.0.tgz",
+      "integrity": "sha512-M1unrZ/PZkGkRf0+/AZvWAsN/BdykPIADk4ICFqb3WwZlfdUcfmdkXR3nMwcpX9BMKoRv2nRJ/ucTS8yJ2Gqsg==",
       "license": "MIT",
       "dependencies": {
         "@corti/sdk": "^0.5.0",

--- a/embedded-assistant/react/basic-example/package.json
+++ b/embedded-assistant/react/basic-example/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@corti/embedded-web": "^0.3.1",
+    "@corti/embedded-web": "^1.0.0",
     "@corti/sdk": "^0.10.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/embedded-assistant/react/basic-example/src/App.css
+++ b/embedded-assistant/react/basic-example/src/App.css
@@ -6,8 +6,7 @@
 
 body {
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, sans-serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   background-color: #f5f5f5;
   padding: 20px;
 }
@@ -46,6 +45,10 @@ h1 {
   padding: 10px;
   border-radius: 4px;
   margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
 }
 
 .status.loading {
@@ -68,6 +71,20 @@ h1 {
   padding: 2px 6px;
   border-radius: 3px;
   font-family: monospace;
+}
+
+.retry-button {
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 4px 10px;
+}
+
+.retry-button:hover {
+  background-color: rgba(0, 0, 0, 0.08);
 }
 
 .assistant-container {

--- a/embedded-assistant/react/basic-example/src/components/EmbeddedAssistant.tsx
+++ b/embedded-assistant/react/basic-example/src/components/EmbeddedAssistant.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   CortiEmbeddedReact,
   type CortiEmbeddedReactRef,
@@ -6,31 +6,101 @@ import {
 } from "@corti/embedded-web/react";
 import type { AuthResponse, Status } from "../types";
 
+const EMBEDDED_READY_TIMEOUT_MS = 20_000;
+const INTERACTION_LOADED_TIMEOUT_MS = 20_000;
+const RECOVERY_MESSAGE =
+  "Assistant is taking longer than expected to load. Check your connection, then try again.";
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+function waitForInteractionLoaded(
+  corti: CortiEmbeddedReactRef,
+  startNavigation: () => Promise<void>,
+) {
+  return new Promise<void>((resolve, reject) => {
+    let isSettled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const handleLoaded = () => {
+      settle(() => resolve());
+    };
+
+    const cleanup = () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      corti.removeEventListener("interaction.loaded", handleLoaded);
+    };
+
+    const settle = (complete: () => void) => {
+      if (isSettled) return;
+      isSettled = true;
+      cleanup();
+      complete();
+    };
+
+    const fail = (error: unknown) => {
+      settle(() => reject(error));
+    };
+
+    corti.addEventListener("interaction.loaded", handleLoaded, { once: true });
+
+    timeoutId = setTimeout(() => {
+      fail(new Error(RECOVERY_MESSAGE));
+    }, INTERACTION_LOADED_TIMEOUT_MS);
+
+    void Promise.resolve().then(startNavigation).catch(fail);
+  });
+}
+
 interface EmbeddedAssistantProps {
   baseUrl: string;
   authData: AuthResponse;
 }
 
-export function EmbeddedAssistant({
-  baseUrl,
-  authData,
-}: EmbeddedAssistantProps) {
+export function EmbeddedAssistant({ baseUrl, authData }: EmbeddedAssistantProps) {
   const cortiRef = useRef<CortiEmbeddedReactRef>(null);
   const api = useCortiEmbeddedApi(cortiRef);
+  const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Guard against onReady firing more than once (e.g. React StrictMode double-invocation)
   const hasInitialized = useRef(false);
+  const [embedKey, setEmbedKey] = useState(0);
 
   const [status, setStatus] = useState<Status>({
     message: "Initializing...",
     type: "loading",
   });
 
+  useEffect(() => {
+    hasInitialized.current = false;
+    setStatus({ message: "Initializing...", type: "loading" });
+
+    const timeoutId = setTimeout(() => {
+      hasInitialized.current = true;
+      setStatus({ message: RECOVERY_MESSAGE, type: "error", canRetry: true });
+    }, EMBEDDED_READY_TIMEOUT_MS);
+    readyTimeoutRef.current = timeoutId;
+
+    return () => {
+      clearTimeout(timeoutId);
+      if (readyTimeoutRef.current === timeoutId) readyTimeoutRef.current = null;
+    };
+  }, [embedKey]);
+
   const handleReady = async () => {
     if (hasInitialized.current) return;
     hasInitialized.current = true;
+    if (readyTimeoutRef.current !== null) {
+      clearTimeout(readyTimeoutRef.current);
+      readyTimeoutRef.current = null;
+    }
 
     try {
+      const corti = cortiRef.current;
+      if (!corti) throw new Error("Embedded assistant not found");
+      corti.hide();
+
       setStatus({ message: "Authenticating...", type: "loading" });
       await api.auth(authData);
 
@@ -67,15 +137,28 @@ export function EmbeddedAssistant({
       });
 
       setStatus({ message: "Starting session...", type: "loading" });
-      await api.navigate(`/session/${interaction.id}`);
+      await waitForInteractionLoaded(corti, () =>
+        api.navigate({ path: `/session/${interaction.id}` }),
+      );
+      corti.show();
 
       setStatus({ message: "Session started!", type: "success" });
     } catch (error) {
       setStatus({
-        message: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+        message: `Error: ${getErrorMessage(error)}`,
         type: "error",
+        canRetry: true,
       });
     }
+  };
+
+  const handleRetry = () => {
+    if (readyTimeoutRef.current !== null) {
+      clearTimeout(readyTimeoutRef.current);
+      readyTimeoutRef.current = null;
+    }
+    hasInitialized.current = false;
+    setEmbedKey((key) => key + 1);
   };
 
   const handleEvent = () => {
@@ -86,6 +169,7 @@ export function EmbeddedAssistant({
     setStatus({
       message: `Error: ${event.detail?.message || "Unknown error"}`,
       type: "error",
+      canRetry: true,
     });
   };
 
@@ -96,18 +180,26 @@ export function EmbeddedAssistant({
       <div className="info">
         <h2>About This Example</h2>
         <p>
-          This demonstrates the Corti Embedded Assistant React component using
-          the proper React hooks and API.
+          This demonstrates the Corti Embedded Assistant React component using the proper React
+          hooks and API.
         </p>
       </div>
 
-      <div className={`status ${status.type}`}>{status.message}</div>
+      <div className={`status ${status.type}`}>
+        <span>{status.message}</span>
+        {status.canRetry ? (
+          <button type="button" className="retry-button" onClick={handleRetry}>
+            Retry
+          </button>
+        ) : null}
+      </div>
 
       <div className="assistant-container">
         <CortiEmbeddedReact
+          key={embedKey}
           ref={cortiRef}
           baseURL={baseUrl}
-          visibility="visible"
+          visibility="hidden"
           onReady={handleReady}
           onEvent={handleEvent}
           onError={handleError}

--- a/embedded-assistant/react/basic-example/src/types.ts
+++ b/embedded-assistant/react/basic-example/src/types.ts
@@ -21,4 +21,5 @@ export type StatusType = "loading" | "success" | "error";
 export interface Status {
   message: string;
   type: StatusType;
+  canRetry?: boolean;
 }

--- a/embedded-assistant/vanilla-ts/basic-example/README.md
+++ b/embedded-assistant/vanilla-ts/basic-example/README.md
@@ -7,14 +7,14 @@ Minimal vanilla TypeScript example showing how to integrate the Corti Embedded A
 1. **Authenticates** with Corti using ROPC flow via backend
 2. **Configures** app-level UI and interaction options using the current Embedded API
 3. **Creates an interaction** with encounter details
-4. **Navigates** to the session view
-5. **Handles** events and errors from the embedded component
+4. **Navigates** to the session view and waits for `interaction.loaded`
+5. **Handles** lifecycle timeouts, retry, events, and errors from the embedded component
 
 ## What This Example Doesn't Cover
 
 - Customisation
 - Advanced event handling
-- Production error handling patterns
+- Production observability patterns
 - State management
 
 ## Quick Start
@@ -54,18 +54,19 @@ This starts both the TypeScript compiler in watch mode and the server. Opens on 
 
 - **[index.html](index.html)** - Main HTML page:
   - **Import map** - Maps `@corti/embedded-web` to the served bundle
-  - **Web component** - `<corti-embedded>` element with `baseUrl` and `visibility` attributes
-  - **Status display** - Shows loading/success/error states
+  - **Web component** - `<corti-embedded>` element with `baseUrl` and hidden initial `visibility`
+  - **Status display** - Shows loading/success/error states and a retry action
   - Server injects `baseUrl` by replacing `{{baseUrl}}` placeholder
 
 - **[public/app.ts](public/app.ts)** - Main application logic:
   - **Component access** - Gets `<corti-embedded>` element by ID and casts to API type
-  - **Readiness check** - Waits for the `embedded.ready` event before starting API calls
+  - **Readiness check** - Waits for the `embedded.ready` event with a timeout before starting API calls
   - **Authentication** - Calls `corti.auth()` with credentials from `/api/auth`
   - **App configuration** - Calls `corti.configureApp()` for app-level UI options
   - **Interaction options** - Calls `corti.setInteractionOptions()` before creating the interaction
   - **Interaction creation** - Creates encounter with `corti.createInteraction()`
-  - **Navigation** - Calls `corti.navigate()` to session view
+  - **Navigation** - Calls `corti.navigate()` to session view and waits for `interaction.loaded` before showing the embed
+  - **Lifecycle recovery** - Remounts the web component when the user retries after a timeout or error
   - **Error handling** - Listens for `error` events and displays status
   - Auto-compiles to `public/app.js` in watch mode during development
 
@@ -86,8 +87,9 @@ This starts both the TypeScript compiler in watch mode and the server. Opens on 
 ```typescript
 // Get embedded element reference
 const corti = document.getElementById("assistant") as CortiEmbeddedElement;
+corti.hide();
 
-const readyPromise = waitForReady(corti);
+const readyPromise = waitForEvent(corti, "embedded.ready", 20000);
 const authPromise = fetch("/api/auth").then((response) => response.json());
 
 const [, credentials] = await Promise.all([readyPromise, authPromise]);
@@ -113,7 +115,10 @@ await corti.setInteractionOptions({
   },
 });
 const interaction = await corti.createInteraction({ encounter: {...} });
-await corti.navigate(`/session/${interaction.id}`);
+await waitForInteractionLoaded(corti, () =>
+  corti.navigate({ path: `/session/${interaction.id}` }),
+);
+corti.show();
 
 // Handle errors
 corti.addEventListener("error", (event: any) => {

--- a/embedded-assistant/vanilla-ts/basic-example/index.html
+++ b/embedded-assistant/vanilla-ts/basic-example/index.html
@@ -13,8 +13,8 @@
 
       body {
         font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-          Cantarell, sans-serif;
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+          sans-serif;
         background-color: #f5f5f5;
         padding: 20px;
       }
@@ -41,6 +41,10 @@
         padding: 10px;
         border-radius: 4px;
         margin-bottom: 20px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
       }
 
       .status.loading {
@@ -56,6 +60,20 @@
       .status.error {
         background-color: #f8d7da;
         color: #721c24;
+      }
+
+      .retry-button {
+        border: 1px solid currentColor;
+        border-radius: 4px;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        padding: 4px 10px;
+      }
+
+      .retry-button:hover {
+        background-color: rgba(0, 0, 0, 0.08);
       }
 
       .assistant-container {
@@ -75,19 +93,15 @@
       <div class="info">
         <h2>About This Example</h2>
         <p>
-          This demonstrates the Corti Embedded Assistant Web Component using
-          vanilla TypeScript.
+          This demonstrates the Corti Embedded Assistant Web Component using vanilla TypeScript.
         </p>
       </div>
 
       <div id="status" class="status loading">Initializing...</div>
+      <button id="retry" class="retry-button" type="button" hidden>Retry</button>
 
       <div class="assistant-container">
-        <corti-embedded
-          id="assistant"
-          baseUrl="{{baseUrl}}"
-          visibility="visible"
-        ></corti-embedded>
+        <corti-embedded id="assistant" baseUrl="{{baseUrl}}" visibility="hidden"></corti-embedded>
       </div>
     </div>
 

--- a/embedded-assistant/vanilla-ts/basic-example/package-lock.json
+++ b/embedded-assistant/vanilla-ts/basic-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "embedded-assistant-vanilla-basic",
       "version": "0.0.1",
       "dependencies": {
-        "@corti/embedded-web": "^0.3.1",
+        "@corti/embedded-web": "^1.0.0",
         "@corti/sdk": "^0.10.1"
       },
       "devDependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@corti/embedded-web": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-0.3.1.tgz",
-      "integrity": "sha512-klRYRvaxpeIXkqq4e4FYF5/Zoq7zwCkQVKICw3H3V1NpSpxcYidFq2TQ9AENezpV63obS3eoAWZuRw2f/tNNBA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@corti/embedded-web/-/embedded-web-1.0.0.tgz",
+      "integrity": "sha512-M1unrZ/PZkGkRf0+/AZvWAsN/BdykPIADk4ICFqb3WwZlfdUcfmdkXR3nMwcpX9BMKoRv2nRJ/ucTS8yJ2Gqsg==",
       "license": "MIT",
       "dependencies": {
         "@corti/sdk": "^0.5.0",

--- a/embedded-assistant/vanilla-ts/basic-example/package.json
+++ b/embedded-assistant/vanilla-ts/basic-example/package.json
@@ -10,7 +10,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@corti/embedded-web": "^0.3.1",
+    "@corti/embedded-web": "^1.0.0",
     "@corti/sdk": "^0.10.1"
   },
   "devDependencies": {

--- a/embedded-assistant/vanilla-ts/basic-example/public/app.ts
+++ b/embedded-assistant/vanilla-ts/basic-example/public/app.ts
@@ -3,9 +3,79 @@ import type { CortiEmbeddedAPI } from "@corti/embedded-web";
 
 type CortiEmbeddedElement = HTMLElement & CortiEmbeddedAPI;
 
-function waitForReady(corti: CortiEmbeddedElement) {
-  return new Promise<void>((resolve) => {
-    corti.addEventListener("embedded.ready", () => resolve(), { once: true });
+const EMBEDDED_READY_TIMEOUT_MS = 20_000;
+const INTERACTION_LOADED_TIMEOUT_MS = 20_000;
+const RECOVERY_MESSAGE =
+  "Assistant is taking longer than expected to load. Check your connection, then try again.";
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Unknown error";
+}
+
+function waitForEvent(corti: CortiEmbeddedElement, eventName: string, timeoutMs: number) {
+  return new Promise<void>((resolve, reject) => {
+    let isSettled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const handleEvent = () => {
+      settle(() => resolve());
+    };
+
+    const cleanup = () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      corti.removeEventListener(eventName, handleEvent);
+    };
+
+    const settle = (complete: () => void) => {
+      if (isSettled) return;
+      isSettled = true;
+      cleanup();
+      complete();
+    };
+
+    corti.addEventListener(eventName, handleEvent, { once: true });
+
+    timeoutId = setTimeout(() => {
+      settle(() => reject(new Error(RECOVERY_MESSAGE)));
+    }, timeoutMs);
+  });
+}
+
+function waitForInteractionLoaded(
+  corti: CortiEmbeddedElement,
+  startNavigation: () => Promise<void>,
+) {
+  return new Promise<void>((resolve, reject) => {
+    let isSettled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const handleLoaded = () => {
+      settle(() => resolve());
+    };
+
+    const cleanup = () => {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      corti.removeEventListener("interaction.loaded", handleLoaded);
+    };
+
+    const settle = (complete: () => void) => {
+      if (isSettled) return;
+      isSettled = true;
+      cleanup();
+      complete();
+    };
+
+    const fail = (error: unknown) => {
+      settle(() => reject(error));
+    };
+
+    corti.addEventListener("interaction.loaded", handleLoaded, { once: true });
+
+    timeoutId = setTimeout(() => {
+      fail(new Error(RECOVERY_MESSAGE));
+    }, INTERACTION_LOADED_TIMEOUT_MS);
+
+    void Promise.resolve().then(startNavigation).catch(fail);
   });
 }
 
@@ -13,9 +83,7 @@ async function fetchAuthData() {
   const authRes = await fetch("/api/auth");
   if (!authRes.ok) {
     const errorBody = await authRes.json().catch(() => null);
-    throw new Error(
-      errorBody?.message ?? `Authentication failed (${authRes.status})`,
-    );
+    throw new Error(errorBody?.message ?? `Authentication failed (${authRes.status})`);
   }
 
   return authRes.json();
@@ -23,85 +91,100 @@ async function fetchAuthData() {
 
 async function main() {
   const statusDiv = document.getElementById("status");
-  function setStatus(msg: string, type: "loading" | "success" | "error") {
+  const retryButton = document.getElementById("retry") as HTMLButtonElement | null;
+
+  function setStatus(msg: string, type: "loading" | "success" | "error", canRetry = false) {
     if (statusDiv) {
       statusDiv.textContent = msg;
       statusDiv.className = `status ${type}`;
     }
+    if (retryButton) retryButton.hidden = !canRetry;
   }
 
-  setStatus("Initializing...", "loading");
+  function getCortiElement() {
+    const corti = document.getElementById("assistant") as CortiEmbeddedElement | null;
+    if (!corti) throw new Error("Embedded assistant not found");
+    return corti;
+  }
 
-  try {
-    // Use the existing CortiEmbeddedWeb instance from the DOM
-    const corti = document.getElementById("assistant") as CortiEmbeddedElement;
-    if (!corti) {
-      setStatus("Error: Embedded assistant not found", "error");
-      return;
-    }
+  function replaceCortiElement() {
+    const currentCorti = getCortiElement();
+    const freshCorti = currentCorti.cloneNode(false) as CortiEmbeddedElement;
+    freshCorti.setAttribute("visibility", "hidden");
+    currentCorti.replaceWith(freshCorti);
+    return freshCorti;
+  }
 
-    // Set up error listener
+  async function start(corti: CortiEmbeddedElement) {
+    setStatus("Initializing...", "loading");
+    corti.hide();
+
     corti.addEventListener("error", (event: any) => {
-      setStatus(`Error: ${event.detail?.message || "Unknown error"}`, "error");
+      setStatus(`Error: ${event.detail?.message || "Unknown error"}`, "error", true);
     });
 
-    const readyPromise = waitForReady(corti);
+    const readyPromise = waitForEvent(corti, "embedded.ready", EMBEDDED_READY_TIMEOUT_MS);
     const authPromise = fetchAuthData();
 
-    try {
-      setStatus("Preparing session...", "loading");
-      const [, authData] = await Promise.all([readyPromise, authPromise]);
+    setStatus("Preparing session...", "loading");
+    const [, authData] = await Promise.all([readyPromise, authPromise]);
 
-      setStatus("Authenticating...", "loading");
-      await corti.auth(authData);
+    setStatus("Authenticating...", "loading");
+    await corti.auth(authData);
 
-      await corti.configureApp({
-        ui: {
-          interactionTitle: true,
-          aiChat: true,
-          documentFeedback: true,
-          navigation: true,
+    await corti.configureApp({
+      ui: {
+        interactionTitle: true,
+        aiChat: true,
+        documentFeedback: true,
+        navigation: true,
+      },
+    });
+
+    await corti.setInteractionOptions({
+      mode: {
+        fallback: "in-person",
+        options: ["in-person", "virtual"],
+      },
+      documents: {
+        actions: {
+          sync: true,
         },
-      });
+      },
+    });
 
-      await corti.setInteractionOptions({
-        mode: {
-          fallback: "in-person",
-          options: ["in-person", "virtual"],
-        },
-        documents: {
-          actions: {
-            sync: true,
-          },
-        },
-      });
+    setStatus("Creating interaction...", "loading");
+    const interaction = await corti.createInteraction({
+      assignedUserId: null,
+      encounter: {
+        identifier: `encounter-${Date.now()}`,
+        status: "planned",
+        type: "first_consultation",
+        period: { startedAt: new Date().toISOString() },
+      },
+    });
 
-      setStatus("Creating interaction...", "loading");
-      const interaction = await corti.createInteraction({
-        assignedUserId: null,
-        encounter: {
-          identifier: `encounter-${Date.now()}`,
-          status: "planned",
-          type: "first_consultation",
-          period: { startedAt: new Date().toISOString() },
-        },
-      });
-
-      setStatus("Starting session...", "loading");
-      await corti.navigate(`/session/${interaction.id}`);
-      setStatus("Session started!", "success");
-    } catch (err) {
-      setStatus(
-        `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-        "error",
-      );
-    }
-  } catch (err) {
-    setStatus(
-      `Error: ${err instanceof Error ? err.message : "Unknown error"}`,
-      "error",
+    setStatus("Starting session...", "loading");
+    await waitForInteractionLoaded(corti, () =>
+      corti.navigate({ path: `/session/${interaction.id}` }),
     );
+    corti.show();
+    setStatus("Session started!", "success");
   }
+
+  async function startWithStatus(corti: CortiEmbeddedElement) {
+    try {
+      await start(corti);
+    } catch (error) {
+      setStatus(`Error: ${getErrorMessage(error)}`, "error", true);
+    }
+  }
+
+  retryButton?.addEventListener("click", () => {
+    void startWithStatus(replaceCortiElement());
+  });
+
+  void startWithStatus(getCortiElement());
 }
 
 main();


### PR DESCRIPTION
## Summary

- Bump the React and vanilla embedded Assistant examples to `@corti/embedded-web@1.0.0`.
- Update the examples to use the latest object-form `navigate({ path })` API.
- Add docs-guided lifecycle handling: keep the embed hidden until navigation completes, wait for `interaction.loaded`, and show a retry state on lifecycle timeouts.
- Refresh the example READMEs to point readers at the timeout, retry, and hidden-until-loaded behavior.

## Related

- Linear: DXA-3728
- Co-dependent docs PR: https://github.com/corticph/docs_corti/pull/818